### PR TITLE
Various enhancements and fixes

### DIFF
--- a/CodeGen/CodeGen.dbl
+++ b/CodeGen/CodeGen.dbl
@@ -1095,6 +1095,12 @@ proc
         end
     end
 	
+    if (ok && CommandLineParser.Parse("ff"))
+    begin
+        task.FilesFirst = true
+    end
+
+
     ;;-------------------------------------------------------------------------
     ;;Are we being asked to process multiple structures at the same time (in the same template)
 	

--- a/CodeGenEngine/CodeGenContext.dbl
+++ b/CodeGenEngine/CodeGenContext.dbl
@@ -76,6 +76,8 @@ namespace CodeGen.Engine
 		;;; </summary>
 		public readwrite property Structures,				@RpsStructureCollection
 
+        public readwrite property Files,                    @RpsFileCollection
+
 		;;; <summary>
 		;;; Exposes the full repository to the parser environment
 		;;; </summary>
@@ -86,7 +88,8 @@ namespace CodeGen.Engine
 		public readwrite property Buttons,					@WscButtonCollection
 		public readwrite property Counter1,					int
 		public readwrite property Counter2,					int
-		public readwrite property CurrentFileIndex,			int
+        public readwrite property CurrentFileIndex,			int
+        public readwrite property CurrentFile,              @RpsFile
 		public readwrite property CurrentStructure,			@RpsStructure
 		public readwrite property CurrentTask,				@CodeGenTask
 		public readwrite property CurrentTemplate,			String
@@ -102,7 +105,8 @@ namespace CodeGen.Engine
 
 		public readwrite property FileDefinition,			@RpsFile
 		public readwrite property MultiStructureMode,		boolean
-		public readwrite property OutputFolder,				String
+        public readwrite property FilesFirstMode,   		boolean
+        public readwrite property OutputFolder,				String
 		public readwrite property SelectionWindowScript,	String
 		public readwrite property StructureFileIndex,		[#]int
 		public readwrite property TemplateFiles,			@List<String>
@@ -122,12 +126,14 @@ namespace CodeGen.Engine
 			Buttons = new WscButtonCollection()
 			Counter1 = 0
 			Counter2 = 0
-			CurrentFileIndex = 0
+            CurrentFileIndex = 0
+            CurrentFile = ^null
 			CurrentStructure = ^null
 			CurrentTask = ^null
-			CurrentTemplate = String.Empty
+            CurrentTemplate = String.Empty            
 			FileDefinition = ^null
-			MultiStructureMode = false
+            MultiStructureMode = false
+            FilesFirstMode = false
 			OutputFolder = String.Empty
 			SelectionWindowScript = String.Empty
 			StructureFileIndex = ^null

--- a/CodeGenEngine/CodeGenEngine.synproj
+++ b/CodeGenEngine/CodeGenEngine.synproj
@@ -144,6 +144,7 @@
     <Compile Include="ExpressionEvaluators\ExpressionEvaluatorFieldLoop.dbl" />
     <Compile Include="ExpressionEvaluators\ExpressionEvaluatorFieldSelectionLoop.dbl" />
     <Compile Include="ExpressionEvaluators\ExpressionEvaluatorFileLoop.dbl" />
+    <Compile Include="ExpressionEvaluators\ExpressionEvaluatorFilesLoop.dbl" />
     <Compile Include="ExpressionEvaluators\ExpressionEvaluatorGeneric.dbl" />
     <Compile Include="ExpressionEvaluators\ExpressionEvaluatorInterfaceLoop.dbl" />
     <Compile Include="ExpressionEvaluators\ExpressionEvaluatorKeyLoop.dbl" />
@@ -179,6 +180,7 @@
     <Compile Include="TokenExpanders\TokenExpanderEnumMemberLoop.dbl" />
     <Compile Include="TokenExpanders\TokenExpanderFieldLoop.dbl" />
     <Compile Include="TokenExpanders\TokenExpanderFileLoop.dbl" />
+    <Compile Include="TokenExpanders\TokenExpanderFilesLoop.dbl" />
     <Compile Include="TokenExpanders\TokenExpanderGeneric.dbl" />
     <Compile Include="TokenExpanders\TokenExpanderInterfaceLoop.dbl" />
     <Compile Include="TokenExpanders\TokenExpanderKeyLoop.dbl" />

--- a/CodeGenEngine/CodeGenTask.dbl
+++ b/CodeGenEngine/CodeGenTask.dbl
@@ -178,6 +178,8 @@ namespace CodeGen.Engine
             endmethod
         endproperty
 
+        public readwrite property FilesFirst, boolean;
+
         ;;; <summary>
         ;;;	File Overrides. This option allows you to specify which repository file definition is
         ;;; used for each structure that you are processing. This option is useful if the structure

--- a/CodeGenEngine/CodeGenerator.dbl
+++ b/CodeGenEngine/CodeGenerator.dbl
@@ -1040,7 +1040,7 @@ namespace CodeGen.Engine
 
             ;;-------------------------------------------------------------------------
             ;;Do we have Repository structures specified in the task?
-
+            context.Files = new @RpsFileCollection()
             if (!errStatus && (context.CurrentTask.Structures.Count>0))
             begin
                 if (context.FileDefinition!=^null) then
@@ -1059,7 +1059,9 @@ namespace CodeGen.Engine
                         begin
                             context.Structures = new RpsStructureCollection(RpsLoadMode.Load,context.CurrentTask.UseAlternateFieldNames)
                             if (context.Structures.Count == 0)
+                            begin
                                 errStatus = context.CurrentTask.Errorlog("Your repository contains no structures!")
+                            end
                         end
                         catch (ex, @RpsException)
                         begin
@@ -1097,6 +1099,15 @@ namespace CodeGen.Engine
                     ;;Default all structures to use the first file assigned
                     if (!errStatus)
                     begin
+                        data str1, @RpsStructure
+                        foreach str1 in context.Structures
+                        begin
+                            if (str1.Files.Count > 0)
+                            begin
+                                context.Files.Merge(str1.Files)
+                            end
+                        end
+
                         data ix, int
                         context.StructureFileIndex = new int[context.Structures.Count]
                         for ix from 0 thru context.Structures.Count - 1
@@ -1422,6 +1433,18 @@ namespace CodeGen.Engine
                 end
             end
 
+            if (!errStatus && (context.CurrentTask.FilesFirst))
+            begin
+                ;;Make sure that we have at least one structures
+                if ((context.FileDefinition==^null) && (context.Files.Count<1)) then
+                    errStatus = context.CurrentTask.Errorlog("Processing multiple files first (-ff) requires that you specify repository structures!")
+                else
+                begin
+                    context.FilesFirstMode = true
+                    context.CurrentTask.VerboseLog(String.Format("Processing {0} files first",context.Files.Count),true,false)
+                end
+            end
+
             ;;-------------------------------------------------------------------------
             ;;Are we being asked to process a user defined token file?
 
@@ -1555,7 +1578,7 @@ namespace CodeGen.Engine
 
                     context.CurrentTask.DebugLog(" - Tree expansion phase beginning", false, true)
 
-                    ;;Are we processing multiple structures at the same time?
+                    ;;Are we processing multiple structures at the same time?                    
                     if (context.MultiStructureMode) then
                     begin
                         ;;Process the template once for all structures
@@ -1574,7 +1597,10 @@ namespace CodeGen.Engine
                         begin
                             ;;Set the initial context to the first structure. This isn't required for <STRUCTURE_LOOP> but will ensure that
                             ;;the default context is <STRUCTURE#1> if <STRUCTURE_LOOP> is not used.
-                            context.CurrentStructure = context.Structures[0]
+                            if (context.CurrentTask.FilesFirst) then
+                                context.CurrentFile = context.Files[0]
+                            else
+                                context.CurrentStructure = context.Structures[0]
 
                             ;;Generate the code
                             errStatus = expandTreeToCode(tree)
@@ -1582,30 +1608,13 @@ namespace CodeGen.Engine
                     end
                     else
                     begin
-                        if (context.Structures.Count > 0) then
+                        if (context.CurrentTask.FilesFirst) then
                         begin
-                            ;;Process the template once per structure
-                            data ix, int
-                            for ix from 0 thru context.Structures.Count-1
-                            begin
-                                ;;Check the structure, flatten arrays and groups, etc.
-                                if (!RepositoryTools.CheckStructure(context,context.Structures[ix])) then
-                                    errStatus = true
-                                else
-                                begin
-                                    ;;Set structure context
-                                    context.CurrentStructure = context.Structures[ix]
-
-                                    ;;Set the file reference to use
-                                    context.CurrentFileIndex = context.StructureFileIndex[ix]
-
-                                    ;;Generate the code
-                                    errStatus = expandTreeToCode(tree)
-                                end
-                                ;;Bail structure loop on failure?
-                                if ((errStatus) && (!context.Taskset.ContinueAfterError))
-                                    exitloop
-                            end
+                            errStatus = generateCodeByFiles(tree);
+                        end
+                        else if (context.Structures.Count > 0) then
+                        begin
+                            errStatus = generateCodeByStructure(tree);
                         end
                         else
                         begin
@@ -1627,12 +1636,72 @@ namespace CodeGen.Engine
 
         endmethod
 
+        private method generateCodeByStructure, boolean
+            required in tree, @FileNode
+        proc
+            ;;Process the template once per structure
+            data ix, int
+            data errStatus, boolean
+            errStatus = false
+
+            for ix from 0 thru context.Structures.Count-1
+            begin
+                ;;Check the structure, flatten arrays and groups, etc.
+                if (!RepositoryTools.CheckStructure(context,context.Structures[ix])) then
+                    errStatus = true
+                else
+                begin
+                    ;;Set structure context
+                    context.CurrentStructure = context.Structures[ix]
+
+                    ;;Set the file reference to use
+                    context.CurrentFileIndex = context.StructureFileIndex[ix]
+
+                    ;;Generate the code
+                    errStatus = expandTreeToCode(tree)
+                end
+                ;;Bail structure loop on failure?
+                if ((errStatus) && (!context.Taskset.ContinueAfterError))
+                    exitloop
+            end
+            mreturn errStatus
+        endmethod
+
+        private method generateCodeByFiles, boolean
+            required in tree, @FileNode
+        proc
+            ;;Process the template once per structure
+            data ix, int
+            data errStatus, boolean
+            errStatus = false
+
+            for ix from 0 thru context.Files.Count-1
+            begin
+                context.CurrentFile = context.Files[ix]
+
+                ;;Set structure context
+                context.CurrentStructure = ^null                
+                context.Structures = context.CurrentFile.Structures
+
+                ;;Set the file reference to use
+                context.CurrentFileIndex = 0
+
+                ;;Generate the code
+                errStatus = expandTreeToCode(tree)
+
+                ;;Bail structure loop on failure?
+                if ((errStatus) && (!context.Taskset.ContinueAfterError))
+                    exitloop
+            end
+            mreturn errStatus
+        endmethod
+
         private method expandTreeToCode, boolean
             required in tree, @FileNode
         proc
             data errStatus = false
 
-            if (context.Structures.Count > 0 && !context.MultiStructureMode)
+            if (!context.MultiStructureMode && context.CurrentStructure != ^null)
                 context.CurrentTask.VerboseLog(String.Format(" - Processing structure {0}",context.CurrentStructure.Name))
 
             ;;Create a stream for the TreeExpander to write the generated code to
@@ -1655,7 +1724,7 @@ namespace CodeGen.Engine
             catch (ex, @Exception)
             begin
                 ;;Something unexpected!
-                errStatus = context.CurrentTask.ErrorLog(String.Format("Unexpected error during tree expansion. Error was {0}", ex.Message))
+                errStatus = context.CurrentTask.ErrorLog(String.Format("Unexpected error during tree expansion. {1} was {0}", ex.Message, ex.GetType().Name))
                 generatedCode.Close()
                 context.CurrentTask.FilesFailed += 1
                 if (context.Taskset.ThrowOnError)

--- a/CodeGenEngine/ExpressionEvaluators/ExpressionEvaluator.dbl
+++ b/CodeGenEngine/ExpressionEvaluators/ExpressionEvaluator.dbl
@@ -69,6 +69,7 @@ namespace CodeGen.Engine
             registerFieldLoopExpressions()
             registerSelectionLoopExpressions()
             registerFileLoopExpressions()
+            registerFilesLoopExpressions()
             registerGenericExpressions()
             registerKeyLoopExpressions()
             registerSegmentLoopExpressions()
@@ -164,8 +165,6 @@ namespace CodeGen.Engine
 			data findAndRunEvaluator, @Func<Dictionary<string, Func<Token, FileNode, IEnumerable<LoopNode>, boolean>>, boolean>, doFindAndRunEvaluator
 			
 			using currentContext select
-            (TokenType.Generic),
-                mreturn findAndRunEvaluator(genericExpressionEvaluators)
             (TokenType.NotInLoop),
                 mreturn findAndRunEvaluator(notInLoopExpressionEvaluators)
             (TokenType.LoopUtility), ;TODO: Bug? Not sure we can ever get here?
@@ -190,6 +189,8 @@ namespace CodeGen.Engine
                 mreturn findAndRunEvaluator(buttonLoopExpressionEvaluators)
             (TokenType.FileLoop),
                 mreturn findAndRunEvaluator(fileLoopExpressionEvaluators)
+            (TokenType.FilesLoop),
+                mreturn findAndRunEvaluator(filesLoopExpressionEvaluators)
             (TokenType.TagLoop),
                 mreturn findAndRunEvaluator(tagLoopExpressionEvaluators)
             (TokenType.StructureLoop),
@@ -201,7 +202,7 @@ namespace CodeGen.Engine
 			(TokenType.ParameterLoop),
 				mreturn findAndRunEvaluator(parameterLoopExpressionEvaluators)
 			(),
-                throw new ApplicationException(badEvaluationRequestMessage())
+                mreturn findAndRunEvaluator(genericExpressionEvaluators)
             endusing
 		
 		endmethod
@@ -241,6 +242,8 @@ namespace CodeGen.Engine
 						tagLoopExpressionEvaluators.Add(customEvaluator.Item1, customEvaluator.Item4)
                     (TokenValidity.FileLoop),
 						fileLoopExpressionEvaluators.Add(customEvaluator.Item1, customEvaluator.Item4)
+                    (TokenValidity.FilesLoop),
+                        filesLoopExpressionEvaluators.Add(customEvaluator.Item1, customEvaluator.Item4)
                     (TokenValidity.ButtonLoop),
 						buttonLoopExpressionEvaluators.Add(customEvaluator.Item1, customEvaluator.Item4)
                     (TokenValidity.StructureLoop),

--- a/CodeGenEngine/ExpressionEvaluators/ExpressionEvaluatorFilesLoop.dbl
+++ b/CodeGenEngine/ExpressionEvaluators/ExpressionEvaluatorFilesLoop.dbl
@@ -1,0 +1,498 @@
+;; *****************************************************************************
+;; 
+;;  Title:       ExpressionEvaluatorFilesLoop.dbl
+;; 
+;;  Type:        Partial class
+;; 
+;;  Description: Evaluates files loop expression nodes
+;; 
+;;  Date:        17th September 2019
+;; 
+;;  Author:      Mark Brugnoli-Vinten
+;; 
+;; *****************************************************************************
+;; 
+;;  Copyright (c) 2014, Synergex International, Inc.
+;;  All rights reserved.
+;; 
+;;  Redistribution and use in source and binary forms, with or without
+;;  modification, are permitted provided that the following conditions are met:
+;; 
+;;  * Redistributions of source code must retain the above copyright notice,
+;;    this list of conditions and the following disclaimer.
+;; 
+;;  * Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;; 
+;;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+;;  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;  POSSIBILITY OF SUCH DAMAGE.
+;; 
+;; *****************************************************************************
+
+import System
+import System.Collections.Generic
+import System.Linq
+import System.Text
+import System.Threading.Tasks
+import CodeGen.RepositoryAPI
+
+.array 0
+
+namespace CodeGen.Engine
+
+    public partial class ExpressionEvaluator
+
+        filesLoopExpressionEvaluators, @Dictionary<string, Func<Token, FileNode, IEnumerable<LoopNode>, boolean>>
+
+        private method registerFilesLoopExpressions, void
+            endparams
+        proc
+			
+            filesLoopExpressionEvaluators = new Dictionary<string, Func<Token, FileNode, IEnumerable<LoopNode>, boolean>>()
+			
+            filesLoopExpressionEvaluators.Add("ASCII", evaluateFSloopAscii)
+            filesLoopExpressionEvaluators.Add("CHANGE_TRACKING", evaluateFSloopChangeTracking)
+            filesLoopExpressionEvaluators.Add("DESCRIPTION", evaluateFSloopDescription)
+            filesLoopExpressionEvaluators.Add("ISAM", evaluateFSloopIsam)
+            filesLoopExpressionEvaluators.Add("NOCHANGE_TRACKING", evaluateFSloopNoChangeTracking)
+            filesLoopExpressionEvaluators.Add("NODESCRIPTION", evaluateFSloopNoDescription)
+            filesLoopExpressionEvaluators.Add("NORECORDCOMPRESSION", evaluateFSloopNoRecordCompression)
+            filesLoopExpressionEvaluators.Add("NOSTORED_GRFA", evaluateFSloopNoStoredGrfa)
+            filesLoopExpressionEvaluators.Add("NOTASCII", evaluateFSloopNotAscii)
+            filesLoopExpressionEvaluators.Add("NOTISAM", evaluateFSloopNotIsam)
+            filesLoopExpressionEvaluators.Add("NOTRECORDTYPEFIXED", evaluateFSloopNotRecordTypeFixed)
+            filesLoopExpressionEvaluators.Add("NOTRECORDTYPEMULTIPLE", evaluateFSloopNotRecordTypeMultiple)
+            filesLoopExpressionEvaluators.Add("NOTRECORDTYPEVARIABLE", evaluateFSloopNotRecordTypeVariable)
+            filesLoopExpressionEvaluators.Add("NOTRELATIVE", evaluateFSloopNotRelative)
+            filesLoopExpressionEvaluators.Add("NOTSTATICRFA", evaluateFSloopNotStaticRfa)
+            filesLoopExpressionEvaluators.Add("NOTTERABYTE", evaluateFSloopNotTerabyte)
+            filesLoopExpressionEvaluators.Add("NOTUSERDEFINED", evaluateFSloopNotUserDefined)
+            filesLoopExpressionEvaluators.Add("NOUSERTEXT", evaluateFSloopNoUserText)
+            filesLoopExpressionEvaluators.Add("PAGESIZE1024", evaluateFSloopPageSize1024)
+            filesLoopExpressionEvaluators.Add("PAGESIZE16384", evaluateFSloopPageSize16384)
+            filesLoopExpressionEvaluators.Add("PAGESIZE2048", evaluateFSloopPageSize2048)
+            filesLoopExpressionEvaluators.Add("PAGESIZE32768", evaluateFSloopPageSize32768)
+            filesLoopExpressionEvaluators.Add("PAGESIZE4096", evaluateFSloopPageSize4096)
+            filesLoopExpressionEvaluators.Add("PAGESIZE512", evaluateFSloopPageSize512)
+            filesLoopExpressionEvaluators.Add("PAGESIZE8192", evaluateFSloopPageSize8192)
+            filesLoopExpressionEvaluators.Add("RECORDCOMPRESSION", evaluateFSloopRecordCompression)
+            filesLoopExpressionEvaluators.Add("RECORDTYPEFIXED", evaluateFSloopRecordTypeFixed)
+            filesLoopExpressionEvaluators.Add("RECORDTYPEMULTIPLE", evaluateFSloopRecordTypeMultiple)
+            filesLoopExpressionEvaluators.Add("RECORDTYPEVARIABLE", evaluateFSloopRecordTypeVariable)
+            filesLoopExpressionEvaluators.Add("RELATIVE", evaluateFSloopRelative)
+            filesLoopExpressionEvaluators.Add("STATICRFA", evaluateFSloopStaticRfa)
+            filesLoopExpressionEvaluators.Add("STORED_GRFA", evaluateFSloopStoredGrfa)
+            filesLoopExpressionEvaluators.Add("TERABYTE", evaluateFSloopTerabyte)
+            filesLoopExpressionEvaluators.Add("USERDEFINED", evaluateFSloopUserDefined)
+            filesLoopExpressionEvaluators.Add("USERTEXT", evaluateFSloopUserText)
+
+        endmethod
+		
+        ;; -------------------------------------------------------------------------------------------------------------------------------
+        ;;; <summary>
+        ;;; 
+        ;;; </summary>
+        ;;; <param name="tkn"></param>
+        ;;; <param name="template"></param>
+        ;;; <param name="loops"></param>
+        ;;; <param name="specific"></param>
+        ;;; <returns></returns>
+        public static method EvaluateFilesLoopExpression, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            specific, @Func<RpsFileCollection, RpsFile, int, boolean> 
+            endparams
+        proc
+            lambda isFilesLoop(node) node .is. FilesLoopNode
+            data loop, @FilesLoopNode
+            if (loops != ^null && loops.Count() > 0) 
+                loop = ^as(loops.FirstOrDefault(isFilesLoop), FilesLoopNode)
+
+            data currentFile, @RpsFile
+            data currentIndex, @int
+            if (loop == ^null) then
+            begin
+                if (template.Context.CurrentFile == ^null || !template.Context.FilesFirstMode)
+                begin
+                    throw new ApplicationException(String.Format("Attempt to use files loop token <{0}> with no current file!",tkn.Value))
+                end
+
+                currentFile = template.Context.CurrentFile
+                currentIndex = -1
+            end
+            else
+            begin
+                currentFile = loop.CurrentFile
+                currentIndex = loop.CurrentIndex
+            end
+
+            mreturn specific(template.Context.Files, currentFile, currentIndex)
+        endmethod
+
+        ;; -------------------------------------------------------------------------------------------------------------------------------
+		
+        private static method evaluateFSloopAscii, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType == "ASCII")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopChangeTracking, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.ChangeTracking)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopDescription, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (!String.IsNullOrWhiteSpace(currentfile.Description))
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopIsam, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType == "DBL ISAM")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNoChangeTracking, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (!currentfile.ChangeTracking)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNoDescription, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (String.IsNullOrWhiteSpace(currentfile.Description))
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNoRecordCompression, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (!currentfile.RecordCompression)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNoStoredGrfa, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (!currentfile.StoredGRFA)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotAscii, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType != "ASCII")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotIsam, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType != "DBL ISAM")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotRecordTypeFixed, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.RecordType != RpsRecordType.FixedLength)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotRecordTypeMultiple, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.RecordType != RpsRecordType.MultipleFixedLength)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotRecordTypeVariable, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.RecordType != RpsRecordType.VariableLength)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotRelative, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType != "RELATIVE")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotStaticRfa, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (!currentfile.StaticRFA)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotTerabyte, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.Addressing == RpsFileAddressing.Addressing32Bit)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNotUserDefined, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType != "USER DEFINED")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopNoUserText, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (String.IsNullOrWhiteSpace(currentfile.UserText))
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopPageSize1024, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.PageSize == RpsFilePageSize.PageSize1024)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopPageSize16384, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.PageSize == RpsFilePageSize.PageSize16384)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopPageSize2048, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.PageSize == RpsFilePageSize.PageSize2048)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopPageSize32768, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.PageSize == RpsFilePageSize.PageSize32768)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopPageSize4096, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.PageSize == RpsFilePageSize.PageSize4096)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopPageSize512, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.PageSize == RpsFilePageSize.PageSize512)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopPageSize8192, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.PageSize == RpsFilePageSize.PageSize8192)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopRecordCompression, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.RecordCompression)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopRecordTypeFixed, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.RecordType == RpsRecordType.FixedLength)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopRecordTypeMultiple, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.RecordType == RpsRecordType.MultipleFixedLength)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopRecordTypeVariable, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.RecordType == RpsRecordType.VariableLength)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopRelative, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType == "RELATIVE")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopStaticRfa, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.StaticRFA)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopStoredGrfa, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.StoredGRFA)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopTerabyte, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.Addressing == RpsFileAddressing.Addressing40Bit)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopUserDefined, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (currentfile.FileType == "USER DEFINED")
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+
+        private static method evaluateFSloopUserText, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, currentfile, index) (!String.IsNullOrWhiteSpace(currentfile.UserText))
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+	
+    endclass
+
+endnamespace
+

--- a/CodeGenEngine/ExpressionEvaluators/ExpressionEvaluatorGeneric.dbl
+++ b/CodeGenEngine/ExpressionEvaluators/ExpressionEvaluatorGeneric.dbl
@@ -79,6 +79,7 @@ namespace CodeGen.Engine
 			
 			;;Structure expressions
 			
+            genericExpressionEvaluators.Add("FSLOOP_STRUCTURES", evaluateFileStructures)
 			genericExpressionEvaluators.Add("STRUCTURE_ASCII", evaluateStructureAscii)
 			genericExpressionEvaluators.Add("STRUCTURE_FILES", evaluateStructureFiles)
 			genericExpressionEvaluators.Add("STRUCTURE_HAS_UNIQUE_KEY", evaluateStructureHasUniqueKey)
@@ -250,7 +251,16 @@ namespace CodeGen.Engine
 			mreturn (template.Context.MultiStructureMode)
 		endmethod
 		
-		private static method evaluateNamespace, boolean
+        private static method evaluateFilesFirst, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            mreturn (template.Context.FilesFirstMode)
+        endmethod
+		
+        private static method evaluateNamespace, boolean
 			tkn, @Token 
 			template, @FileNode 
 			loops, @IEnumerable<LoopNode> 
@@ -309,7 +319,17 @@ namespace CodeGen.Engine
 			mreturn evaluateStructureExpression(tkn, template, loops, doEvaluate)
 		endmethod
 		
-		private static method evaluateStructureHasUniqueKey, boolean
+        private static method evaluateFileStructures, boolean
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doEvaluate(files, file, index) (file.Structures.Count > 0)
+            mreturn EvaluateFilesLoopExpression(tkn, template, loops, doEvaluate)
+        endmethod
+        
+        private static method evaluateStructureHasUniqueKey, boolean
 			tkn, @Token 
 			template, @FileNode 
 			loops, @IEnumerable<LoopNode> 

--- a/CodeGenEngine/LoopExpander.dbl
+++ b/CodeGenEngine/LoopExpander.dbl
@@ -75,6 +75,7 @@ namespace CodeGen.Engine
 			loopProcessors.Add("TO_KEY_SEGMENT_LOOP_RESTRICTED", processToKeySegmentLoopRestricted)
 			loopProcessors.Add("BUTTON_LOOP", processButtonLoop)
             loopProcessors.Add("FILE_LOOP", processFileLoop)
+            loopProcessors.Add("FILES_LOOP", processFilesLoop)
 			loopProcessors.Add("TAG_LOOP", processTagLoop)
             loopProcessors.Add("SELECTION_LOOP", processFieldSelectionLoop)
             loopProcessors.Add("SEGMENT_LOOP", processKeySegmentLoop)
@@ -513,6 +514,33 @@ namespace CodeGen.Engine
 			
         endmethod
 
+        private static method processFilesLoop, void
+            required in node,		@LoopNode 
+            required in template,	@FileNode 
+            required in loops,		@IEnumerable<LoopNode> 
+            required in expander,	@ITreeNodeVisitor 
+        proc
+            data loop = ^as(node, FilesLoopNode)
+            data context = template.Context
+			
+            if (context.Files.Count == 0)
+                throw new ApplicationException(String.Format("The <{0}> loop at line {1} in template {2} can't be processed because there no files!", node.OpenToken.Value, node.OpenToken.StartLineNumber, template.Context.CurrentTemplateBaseName))
+			
+            loop.MaxIndex = context.Files.Count - 1
+
+            context.CurrentTask.DebugLog(String.Format("   - {0,-30} -> {1} files", string.Format("<{0}>", loop.OpenToken.Value), loop.MaxIndex + 1))
+
+            data ix, int
+            for ix from 0 thru context.Files.Count - 1
+            begin
+                loop.CurrentFile = context.Files[ix]
+                loop.CurrentIndex = ix
+                
+                expander.Visit(node.Body)
+            end
+			
+        endmethod
+
         private static method processTagLoop, void
 			required in node,		@LoopNode 
 			required in template,	@FileNode 
@@ -878,24 +906,40 @@ namespace CodeGen.Engine
 			required in loops, @IEnumerable<LoopNode> 
 			required in expander, @ITreeNodeVisitor 
         proc
+			data structures, @RpsStructureCollection
             data loop = ^as(node, StructureLoopNode)
             data context = template.Context
             data task = context.CurrentTask
-			
-			if (!context.MultiStructureMode)
+            
+            if (!context.MultiStructureMode && !context.FilesFirstMode)
                 throw new ApplicationException(String.Format("The <{0}> loop at line {1} in template {2} can't be processed because multi-structure mode (-ms) has not been enabled!", node.OpenToken.Value, node.OpenToken.StartLineNumber, context.CurrentTemplateBaseName))
 			
-			loop.MaxIndex = context.Structures.Count - 1
+            if (context.FilesFirstMode)
+            begin
+                data files = ^as(loops.First(), FilesLoopNode)
+                if (files != ^null)
+                    structures = files.CurrentFile.Structures
+            end
+
+            if (structures == ^null)
+                structures = context.Structures
+
+			loop.MaxIndex = structures.Count - 1
 
             ;; Debug log beginning of structure loop
-			context.CurrentTask.DebugLog(String.Format("   - {0,-30} -> {1} structures", string.Format("<{0}>", loop.OpenToken.Value), context.Structures.Count))
+			context.CurrentTask.DebugLog(String.Format("   - {0,-30} -> {1} structures", string.Format("<{0}>", loop.OpenToken.Value), structures.Count))
 
 			data ix, int
-			for ix from 0 thru context.Structures.Count - 1
+			for ix from 0 thru structures.Count - 1
 			begin
-				context.CurrentTask.DebugLog(String.Format("   - {0,-30} -> {1}", String.Format("Structure {0}/{1}", ix + 1, context.Structures.Count - 1), context.Structures[ix].Name), true, false)
-                context.CurrentStructure = context.Structures[ix]
-                context.CurrentFileIndex = context.StructureFileIndex[ix]
+				context.CurrentTask.DebugLog(String.Format("   - {0,-30} -> {1}", String.Format("Structure {0}/{1}", ix + 1, structures.Count), structures[ix].Name), true, false)
+                context.CurrentStructure = structures[ix]
+                
+                if (context.FilesFirstMode) then
+                    context.CurrentFileIndex = -1
+                else
+                    context.CurrentFileIndex = context.StructureFileIndex[ix]
+
 				loop.CurrentIndex = ix
 
 				expander.Visit(node.Body)

--- a/CodeGenEngine/Parser.dbl
+++ b/CodeGenEngine/Parser.dbl
@@ -268,12 +268,14 @@ namespace CodeGen.Engine
                                 if (topLevelNode.RequiredCustomExpressions == ^null)
                                     topLevelNode.RequiredCustomExpressions = new List<Tuple<TokenValidity, string>>()
                                 topLevelNode.RequiredCustomExpressions.Add(Tuple.Create(TokenValidity.FileLoop, tokens[ix + 1].Value))
+                                topLevelNode.RequiredCustomExpressions.Add(Tuple.Create(TokenValidity.FilesLoop, tokens[ix + 1].Value))
                             end
                             ("REQUIRES_CUSTOM_FILE_TOKEN"),
                             begin
                                 if (topLevelNode.RequiredCustomTokens == ^null)
                                     topLevelNode.RequiredCustomTokens = new List<Tuple<TokenValidity, string>>()
                                 topLevelNode.RequiredCustomTokens.Add(Tuple.Create(TokenValidity.FileLoop, tokens[ix + 1].Value))
+                                topLevelNode.RequiredCustomTokens.Add(Tuple.Create(TokenValidity.FilesLoop, tokens[ix + 1].Value))
                             end
                             ("REQUIRES_CUSTOM_KEY_EXPRESSION"),
                             begin
@@ -495,7 +497,7 @@ namespace CodeGen.Engine
 
                 (TokenType.Text),
                     list.Add(new TextNode() { Value = tkn })
-
+                 
                 (),
                     list.Add(new ExpansionNode() { Value = tkn })
 
@@ -546,6 +548,9 @@ namespace CodeGen.Engine
 
             ("FILE_LOOP"),
                 loop = new FileLoopNode() {OpenToken = tokens[startIndex], Body = new List<ITreeNode>()}
+
+            ("FILES_LOOP"),
+                loop = new FilesLoopNode() {OpenToken = tokens[startIndex], Body = new List<ITreeNode>()}
 
             ("TAG_LOOP"),
                 loop = new TagLoopNode() {OpenToken = tokens[startIndex], Body = new List<ITreeNode>()}

--- a/CodeGenEngine/Token.dbl
+++ b/CodeGenEngine/Token.dbl
@@ -126,7 +126,7 @@ namespace CodeGen.Engine
 			(TokenType.Text),
 				mreturn String.Format("{0}: {1}", TypeOfToken, Value.Replace(%char(13), "<CR>").Replace(%char(10), "<LF>").Replace(%char(9), "<TAB>"))
 			
-			(TokenType.Generic, TokenType.StructureInfo, TokenType.FieldLoop, TokenType.FieldSelectionLoop, TokenType.KeyLoop, TokenType.KeySegmentLoop, TokenType.EnumLoop, TokenType.EnumMemberLoop, TokenType.RelationLoop, TokenType.RelationSegmentLoop, TokenType.ButtonLoop, TokenType.FileLoop, TokenType.TagLoop, TokenType.StructureLoop, TokenType.LoopUtility, TokenType.Window, TokenType.Counter, TokenType.User),
+			(TokenType.Generic, TokenType.StructureInfo, TokenType.FieldLoop, TokenType.FieldSelectionLoop, TokenType.KeyLoop, TokenType.KeySegmentLoop, TokenType.EnumLoop, TokenType.EnumMemberLoop, TokenType.RelationLoop, TokenType.RelationSegmentLoop, TokenType.ButtonLoop, TokenType.FileLoop, TokenType.FilesLoop, TokenType.TagLoop, TokenType.StructureLoop, TokenType.LoopUtility, TokenType.Window, TokenType.Counter, TokenType.User),
 				mreturn String.Format("{0}: <{1}>", TypeOfToken, Value)
 			
 			(TokenType.Control),

--- a/CodeGenEngine/TokenExpanders/TokenExpander.dbl
+++ b/CodeGenEngine/TokenExpanders/TokenExpander.dbl
@@ -65,6 +65,7 @@ namespace CodeGen.Engine
             registerEnumMemberLoopTokens()
             registerFieldLoopTokens()
             registerFileLoopTokens()
+            registerFilesLoopTokens()
             registerGenericTokens()
             registerInterfaceLoopTokens()
             registerKeyLoopTokens()
@@ -230,6 +231,9 @@ namespace CodeGen.Engine
             (TokenType.FileLoop),
                 mreturn findAndRunExpander(fileLoopTokenExpanders)
 
+            (TokenType.FilesLoop),
+                mreturn findAndRunExpander(filesLoopTokenExpanders)
+
             (TokenType.LoopUtility),
                 mreturn findAndRunExpander(loopUtilityTokenExpanders)
 
@@ -354,6 +358,9 @@ namespace CodeGen.Engine
 
                     (TokenValidity.FileLoop),
                         fileLoopTokenExpanders.Add(customExpander.Item1, customExpander.Item5)
+
+                    (TokenValidity.FilesLoop),
+                        filesLoopTokenExpanders.Add(customExpander.Item1, customExpander.Item5)
 
                     (TokenValidity.InterfaceLoop),
                         interfaceLoopTokenExpanders.Add(customExpander.Item1, customExpander.Item5)

--- a/CodeGenEngine/TokenExpanders/TokenExpanderFileLoop.dbl
+++ b/CodeGenEngine/TokenExpanders/TokenExpanderFileLoop.dbl
@@ -70,6 +70,7 @@ namespace CodeGen.Engine
 			fileLoopTokenExpanders.Add("FLOOP_NAME_NOEXT", expandFloopNameNoExt)
 			fileLoopTokenExpanders.Add("FLOOP_ODBC_NAME", expandFloopOdbcName)
 			fileLoopTokenExpanders.Add("FLOOP_PAGESIZE", expandFloopPageSize)
+            fileLoopTokenExpanders.Add("FLOOP_RECORDSIZE", expandFloopRecordSize)
             fileLoopTokenExpanders.Add("FLOOP_RECTYPE", expandFloopRecType)
 			fileLoopTokenExpanders.Add("FLOOP_RPS_NAME", expandFloopRpsName)
 			fileLoopTokenExpanders.Add("FLOOP_STATIC_RFA", expandFloopStaticRfa)
@@ -228,6 +229,20 @@ namespace CodeGen.Engine
                 endusing
                 mreturn value
             end
+            mreturn ExpandFileLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFloopRecordSize, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) 
+            begin
+                mreturn currentFile.RecordSize.ToString()
+            end
+
             mreturn ExpandFileLoopToken(tkn, template, loops, doExpand)
         endmethod
 

--- a/CodeGenEngine/TokenExpanders/TokenExpanderFilesLoop.dbl
+++ b/CodeGenEngine/TokenExpanders/TokenExpanderFilesLoop.dbl
@@ -1,0 +1,341 @@
+;; *****************************************************************************
+;; 
+;;  Title:       TokenExpanderFilesLoop.dbl
+;; 
+;;  Type:        Partial class
+;; 
+;;  Description: Expands files loop token nodes (different to file loop as top
+;;               level and contains all files, not just structure files)
+;; 
+;;  Date:        17th September 2019
+;; 
+;;  Author:      Mark Brugnoli-Vinten
+;; 
+;; *****************************************************************************
+;; 
+;;  Copyright (c) 2014, Synergex International, Inc.
+;;  All rights reserved.
+;; 
+;;  Redistribution and use in source and binary forms, with or without
+;;  modification, are permitted provided that the following conditions are met:
+;; 
+;;  * Redistributions of source code must retain the above copyright notice,
+;;    this list of conditions and the following disclaimer.
+;; 
+;;  * Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;; 
+;;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+;;  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;  POSSIBILITY OF SUCH DAMAGE.
+;; 
+;; *****************************************************************************
+
+import System
+import System.Collections.Generic
+import System.Linq
+import System.Text
+import System.Threading.Tasks
+import CodeGen.RepositoryAPI
+
+.array 0
+
+namespace CodeGen.Engine
+
+    public partial class TokenExpander
+
+        filesLoopTokenExpanders, @Dictionary<string, Func<Token, FileNode, IEnumerable<LoopNode>, string>>
+
+        private method registerFilesLoopTokens, void
+            endparams
+		proc
+
+			filesLoopTokenExpanders = new Dictionary<string, Func<Token, FileNode, IEnumerable<LoopNode>, string>>()
+
+            filesLoopTokenExpanders.Add("FSLOOP_ADDRESSING", expandFSloopAddressing)
+            filesLoopTokenExpanders.Add("FSLOOP_CHANGE_TRACKING", expandFSloopChangeTracking)
+            filesLoopTokenExpanders.Add("FSLOOP_COMPRESSION", expandFSloopCompression)
+            filesLoopTokenExpanders.Add("FSLOOP_DENSITY", expandFSloopDensity)
+            filesLoopTokenExpanders.Add("FSLOOP_DESC", expandFSloopDesc)
+            filesLoopTokenExpanders.Add("FSLOOP_NAME", expandFSloopName)
+			filesLoopTokenExpanders.Add("FSLOOP_NAME_NOEXT", expandFSloopNameNoExt)
+			filesLoopTokenExpanders.Add("FSLOOP_ODBC_NAME", expandFSloopOdbcName)
+            filesLoopTokenExpanders.Add("FSLOOP_PAGESIZE", expandFSloopPageSize)
+            filesLoopTokenExpanders.Add("FSLOOP_RECORDSIZE", expandFSloopRecordSize)
+            filesLoopTokenExpanders.Add("FSLOOP_RECTYPE", expandFSloopRecType)
+			filesLoopTokenExpanders.Add("FSLOOP_RPS_NAME", expandFSloopRpsName)
+			filesLoopTokenExpanders.Add("FSLOOP_STATIC_RFA", expandFSloopStaticRfa)
+            filesLoopTokenExpanders.Add("FSLOOP_STORED_GRFA", expandFSloopStoredGrfa)
+            filesLoopTokenExpanders.Add("FSLOOP_TYPE", expandFSloopType)
+			filesLoopTokenExpanders.Add("FSLOOP_UTEXT", expandFSloopUserText)
+
+        endmethod
+
+        ;;; <summary>
+        ;;; 
+        ;;; </summary>
+        ;;; <param name="tkn"></param>
+        ;;; <param name="template"></param>
+        ;;; <param name="loops"></param>
+        ;;; <param name="specific"></param>
+        ;;; <returns></returns>
+        public static method ExpandFilesLoopToken, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            specific, @Func<RpsFile, string> 
+            endparams
+        proc
+            lambda isFilesLoop(node) node .is. FilesLoopNode
+            data loop, @FilesLoopNode
+            if ((loops != ^null) && (loops.Count() > 0))
+                loop = ^as(loops.FirstOrDefault(isFilesLoop), FilesLoopNode)
+            
+            data currentFile, @RpsFile
+            if (loop != ^null)
+                currentFile = loop.CurrentFile
+
+            if (currentFile == ^null)
+            begin
+                if (template.Context.CurrentFile == ^null || !template.Context.FilesFirstMode)
+                begin
+                    throw new ApplicationException(String.Format("Attempt to use files loop token <{0}> with no current file!",tkn.Value))
+                end
+                currentFile = template.Context.CurrentFile
+            end
+            mreturn specific(currentFile)
+        endmethod
+
+        private static method expandFSloopAddressing, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile)
+            begin
+                data value, string, ""
+                using (currentFile.Addressing) select
+                (RpsFileAddressing.Addressing32Bit),
+                    value = "32"
+                (RpsFileAddressing.Addressing40Bit),
+                    value = "40"
+                endusing
+                mreturn value
+            end
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopChangeTracking, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.ChangeTracking ? "YES" : " NO"
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopCompression, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.RecordCompression ? "YES" : "NO"
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopDensity, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.Density.ToString()
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopDesc, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.Description
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopName, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.FileSpec
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopNameNoExt, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile)
+            begin
+                data value, string, currentFile.FileSpec
+                ;; Remove the file extension
+                if (value.Contains("."))
+                    value = value.Substring(0, value.LastIndexOf("."))
+                mreturn value
+            end
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+		private static method expandFSloopOdbcName, string
+			tkn, @Token 
+			template, @FileNode 
+			loops, @IEnumerable<LoopNode> 
+			endparams
+		proc
+			lambda doExpand(currentFile)
+			begin
+				mreturn currentFile.OdbcTableNames[0]
+			end
+			mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+		endmethod
+
+        private static method expandFSloopPageSize, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile)
+            begin
+                data value, string, ""
+                using (currentFile.PageSize) select
+                (RpsFilePageSize.PageSize512),
+                    value = "512"
+                (RpsFilePageSize.PageSize1024),
+                    value = "1024"
+                (RpsFilePageSize.PageSize2048),
+                    value = "2048"
+                (RpsFilePageSize.PageSize4096),
+                    value = "4096"
+                (RpsFilePageSize.PageSize8192),
+                    value = "8192"
+                (RpsFilePageSize.PageSize16384),
+                    value = "16384"
+                (RpsFilePageSize.PageSize32768),
+                    value = "32768"
+                (),
+                    value = "4096"
+                endusing
+                mreturn value
+            end
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopRecordSize, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile)
+            begin
+                mreturn currentFile.RecordSize.ToString()
+            end
+
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+        
+        private static method expandFSloopRecType, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile)
+            begin
+                data value, string, ""
+                using (currentFile.RecordType) select
+                (RpsRecordType.FixedLength),
+                    value = "FIXED"
+                (RpsRecordType.MultipleFixedLength),
+                    value = "MULTIPLE"
+                (RpsRecordType.VariableLength),
+                    value = "VARIABLE"
+                endusing
+                mreturn value
+            end
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopRpsName, string
+			tkn, @Token 
+			template, @FileNode 
+			loops, @IEnumerable<LoopNode> 
+			endparams
+		proc
+			lambda doExpand(currentFile)
+			begin
+				mreturn currentFile.Name
+			end
+			mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+		endmethod
+
+        private static method expandFSloopStaticRfa, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.StaticRFA ? "YES" : "NO"
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopStoredGrfa, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.StoredGRFA ? "YES" : "NO"
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopType, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.FileType
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+        endmethod
+
+        private static method expandFSloopUserText, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(currentFile) currentFile.UserText
+            mreturn ExpandFilesLoopToken(tkn, template, loops, doExpand)
+		endmethod
+
+	endclass
+
+endnamespace

--- a/CodeGenEngine/TokenExpanders/TokenExpanderNotInLoop.dbl
+++ b/CodeGenEngine/TokenExpanders/TokenExpanderNotInLoop.dbl
@@ -45,6 +45,7 @@ import System.Collections.Generic
 import System.Linq
 import System.Text
 import System.Threading.Tasks
+import CodeGen.RepositoryAPI
 
 .array 0
 
@@ -77,15 +78,21 @@ namespace CodeGen.Engine
             loops, @IEnumerable<LoopNode> 
             endparams
         proc
-            if (!template.Context.MultiStructureMode)
+            if (!template.Context.MultiStructureMode && !template.Context.FilesFirstMode)
                 throw new ApplicationException(String.Format("Token {0} can only be used when processing multiple structures concurrently!", tkn.Value))
 			
-			data newStructureNumber, int, Convert.ToInt32(tkn.Value.Replace("STRUCTURE#", ""))
-            if (newStructureNumber > template.Context.Structures.Count)
-                throw new ApplicationException(String.Format("Token {0} can't be used because you are only processing {1} structures!", tkn.Value, template.Context.Structures.Count))
+            data newStructureNumber, int, Convert.ToInt32(tkn.Value.Replace("STRUCTURE#", ""))
+            data structures, @RpsStructureCollection
+            if (template.Context.FilesFirstMode) then
+                structures = template.Context.CurrentFile.Structures
+            else
+                structures = template.Context.Structures
+
+            if (newStructureNumber > structures.Count)
+                throw new ApplicationException(String.Format("Token {0} can't be used because you are only processing {1} structures!", tkn.Value, structures.Count))
 			
 			;; Make the requested structure the current structure
-            template.Context.CurrentStructure = template.Context.Structures[newStructureNumber - 1]
+            template.Context.CurrentStructure = structures[newStructureNumber - 1]
             template.Context.CurrentTask.DebugLog(String.Format("   - {0,-30} -> {1}", "Change structure", template.Context.CurrentStructure.Name), true, false)
 			
 			mreturn ""

--- a/CodeGenEngine/TokenExpanders/TokenExpanderStructure.dbl
+++ b/CodeGenEngine/TokenExpanders/TokenExpanderStructure.dbl
@@ -74,6 +74,7 @@ namespace CodeGen.Engine
 			structureTokenExpanders.Add("FILE_ODBC_NAME", expandOdbcName)
 			structureTokenExpanders.Add("FILE_PAGESIZE", expandFilePageSize)
 			structureTokenExpanders.Add("FILE_PORTABLE_INT_SPECS", expandFilePortableIntSpecs)
+            structureTokenExpanders.Add("FILE_RECORDSIZE", expandFileRecordSize)
             structureTokenExpanders.Add("FILE_RECTYPE", expandFileRecType)
 			structureTokenExpanders.Add("FILE_RPS_NAME", expandFileRpsName)
 			structureTokenExpanders.Add("FILE_STATIC_RFA", expandFileStaticRfa)
@@ -458,6 +459,23 @@ namespace CodeGen.Engine
 			mreturn ExpandStructureToken(tkn, template, loops, doExpand)
 		endmethod
 
+        private static method expandFileRecordSize, string
+            tkn, @Token 
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+            endparams
+        proc
+            lambda doExpand(str)
+            begin
+                if (str.Files.Count > 0) then
+                begin
+                    mreturn str.Files[template.Context.CurrentFileIndex].RecordSize.ToString()
+                end
+                else
+                    throw new ApplicationException(template.GetTokenErrorMessage(tkn, String.Format("requires structure {0} to be assigned to a file definition", str.Name)))
+            end
+            mreturn ExpandStructureToken(tkn, template, loops, doExpand)
+        endmethod
 
         private static method expandFileRecType, string
             tkn, @Token 

--- a/CodeGenEngine/TokenMeta.dbl
+++ b/CodeGenEngine/TokenMeta.dbl
@@ -75,7 +75,8 @@ namespace CodeGen.Engine
 		StructureLoop
 		InterfaceLoop
 		MethodLoop
-		ParameterLoop
+        ParameterLoop
+        FilesLoop
 	endenum
 	
 	{Flags}
@@ -97,7 +98,9 @@ namespace CodeGen.Engine
 		InterfaceLoop				, 16384
 		MethodLoop					, 32768
 		ParameterLoop				, 65536
-		RelationSegmentLoop			, 131072
+        RelationSegmentLoop			, 131072
+        FilesLoop                   , 262144
+        FilesFirstMode              , 524288
 	endenum
 	
 	public class TokenMeta

--- a/CodeGenEngine/TokenValidation.dbl
+++ b/CodeGenEngine/TokenValidation.dbl
@@ -71,6 +71,8 @@ namespace CodeGen.Engine
 			tokenValidators.Add(TokenValidity.RelationSegmentLoop, isRelationSegmentLoopTokenValid)
             tokenValidators.Add(TokenValidity.ButtonLoop, isButtonLoopTokenValid)
             tokenValidators.Add(TokenValidity.FileLoop, isFileLoopTokenValid)
+            tokenValidators.Add(TokenValidity.FilesLoop, isFilesLoopTokenValid)
+            tokenValidators.Add(TokenValidity.FilesFirstMode, isFirstFirstModeTokenValid)
             tokenValidators.Add(TokenValidity.TagLoop, isTagLoopTokenValid)
             tokenValidators.Add(TokenValidity.StructureLoop, isStructureLoopTokenValid)
 			tokenValidators.Add(TokenValidity.AnyLoop, isAnyLoopTokenValid)
@@ -182,7 +184,21 @@ namespace CodeGen.Engine
             mreturn ((loops.Count() > 0) && (loops.Last() .is. FileLoopNode))
         endmethod
 
-		private static method isTagLoopTokenValid, boolean
+        private static method isFilesLoopTokenValid, boolean
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+        proc
+            mreturn ((loops.Count() > 0) && (loops.Last() .is. FilesLoopNode))
+        endmethod
+
+        private static method isFirstFirstModeTokenValid, boolean
+            template, @FileNode 
+            loops, @IEnumerable<LoopNode> 
+        proc
+            mreturn (template.Context.Files.Count() > 0 && template.Context.FilesFirstMode)
+        endmethod
+
+        private static method isTagLoopTokenValid, boolean
             template, @FileNode 
             loops, @IEnumerable<LoopNode> 
         proc

--- a/CodeGenEngine/Tokenizer.dbl
+++ b/CodeGenEngine/Tokenizer.dbl
@@ -157,7 +157,7 @@ namespace CodeGen.Engine
             &    { new TokenMeta() {Name = "FILE", TypeOfToken = TokenType.PreProcessor, IsPaired = true, Validity = TokenValidity.Anywhere} }, 
             &    { new TokenMeta() {Name = "FILEIFEXIST", TypeOfToken = TokenType.PreProcessor, IsPaired = true, Validity = TokenValidity.Anywhere} }, 
             &    
-            &    { new TokenMeta() {Name = "STRUCTURE_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "STRUCTURE_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop | TokenValidity.FilesLoop, RequiresRepository = true} }, 
             &    
             &    { new TokenMeta() {Name = "FIELD_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop | TokenValidity.StructureLoop | TokenValidity.ParameterLoop, RequiresRepository = true} }, 
             &    { new TokenMeta() {Name = "KEY_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop | TokenValidity.StructureLoop, RequiresRepository = true} }, 
@@ -169,6 +169,7 @@ namespace CodeGen.Engine
             &    { new TokenMeta() {Name = "ENUM_LOOP_STRUCTURE", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop | TokenValidity.StructureLoop, RequiresRepository = true} }, 
             &    { new TokenMeta() {Name = "RELATION_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop | TokenValidity.StructureLoop, RequiresRepository = true} }, 
             &    { new TokenMeta() {Name = "FILE_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop | TokenValidity.StructureLoop, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "FILES_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop, RequiresRepository = true} }, 
             &    { new TokenMeta() {Name = "TAG_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop | TokenValidity.StructureLoop, RequiresRepository = true} }, 
             &    { new TokenMeta() {Name = "BUTTON_LOOP", TypeOfToken = TokenType.Loop, IsPaired = true, Validity = TokenValidity.NotInLoop} }, 
             &    
@@ -235,6 +236,7 @@ namespace CodeGen.Engine
             &    { makeTokenMeta_AllVariants("FILE_ODBC_NAME", TokenType.StructureInfo, TokenValidity.Anywhere, true) }, 
             &    { new TokenMeta() {Name = "FILE_PAGESIZE", TypeOfToken = TokenType.StructureInfo, IsPaired = false, Validity = TokenValidity.Anywhere, RequiresRepository = true} }, 
             &    { new TokenMeta() {Name = "FILE_PORTABLE_INT_SPECS", TypeOfToken = TokenType.StructureInfo, IsPaired = false, Validity = TokenValidity.Anywhere, RequiresRepository = true} },
+            &    { new TokenMeta() {Name = "FILE_RECORDSIZE", TypeOfToken = TokenType.StructureInfo, IsPaired = false, Validity = TokenValidity.Anywhere, RequiresRepository = true} }, 
             &    { makeTokenMeta_UpperLower ("FILE_RECTYPE", TokenType.StructureInfo, TokenValidity.Anywhere, true) }, 
             &    { makeTokenMeta_AllVariants("FILE_RPS_NAME", TokenType.StructureInfo, TokenValidity.Anywhere, true) }, 
             &    { makeTokenMeta_UpperLower ("FILE_STATIC_RFA", TokenType.StructureInfo, TokenValidity.Anywhere, true) }, 
@@ -475,12 +477,30 @@ namespace CodeGen.Engine
             &    { new TokenMeta() {Name = "FLOOP_NAME_NOEXT", TypeOfToken = TokenType.FileLoop, IsPaired = false, Validity = TokenValidity.FileLoop, RequiresRepository = true} }, 
             &    { makeTokenMeta_AllVariants("FLOOP_ODBC_NAME", TokenType.FileLoop, TokenValidity.FileLoop, true) }, 
             &    { new TokenMeta() {Name = "FLOOP_PAGESIZE", TypeOfToken = TokenType.FileLoop, IsPaired = false, Validity = TokenValidity.FileLoop, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "FLOOP_RECORDSIZE", TypeOfToken = TokenType.FileLoop, IsPaired = false, Validity = TokenValidity.FileLoop, RequiresRepository = true} }, 
             &    { makeTokenMeta_UpperLower ("FLOOP_RECTYPE", TokenType.FileLoop, TokenValidity.FileLoop, true) }, 
             &    { makeTokenMeta_AllVariants("FLOOP_RPS_NAME", TokenType.FileLoop, TokenValidity.FileLoop, true) }, 
             &    { makeTokenMeta_UpperLower ("FLOOP_STATIC_RFA", TokenType.FileLoop, TokenValidity.FileLoop, true) }, 
             &    { makeTokenMeta_UpperLower ("FLOOP_STORED_GRFA", TokenType.FileLoop, TokenValidity.FileLoop, true) }, 
             &    { new TokenMeta() {Name = "FLOOP_TYPE", TypeOfToken = TokenType.FileLoop, IsPaired = false, Validity = TokenValidity.FileLoop, RequiresRepository = true} }, 
             &    { new TokenMeta() {Name = "FLOOP_UTEXT", TypeOfToken = TokenType.FileLoop, IsPaired = false, Validity = TokenValidity.FileLoop, RequiresRepository = true} }, 
+            &    
+            &    { new TokenMeta() {Name = "FSLOOP_ADDRESSING", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { makeTokenMeta_UpperLower ("FSLOOP_COMPRESSION", TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true) }, 
+            &    { makeTokenMeta_UpperLower ("FSLOOP_CHANGE_TRACKING", TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true) }, 
+            &    { new TokenMeta() {Name = "FSLOOP_DESC", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "FSLOOP_DENSITY", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "FSLOOP_NAME", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "FSLOOP_NAME_NOEXT", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { makeTokenMeta_AllVariants("FSLOOP_ODBC_NAME", TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true) }, 
+            &    { new TokenMeta() {Name = "FSLOOP_PAGESIZE", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "FSLOOP_RECORDSIZE", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { makeTokenMeta_UpperLower ("FSLOOP_RECTYPE", TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true) }, 
+            &    { makeTokenMeta_AllVariants("FSLOOP_RPS_NAME", TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true) }, 
+            &    { makeTokenMeta_UpperLower ("FSLOOP_STATIC_RFA", TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true) }, 
+            &    { makeTokenMeta_UpperLower ("FSLOOP_STORED_GRFA", TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true) }, 
+            &    { new TokenMeta() {Name = "FSLOOP_TYPE", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
+            &    { new TokenMeta() {Name = "FSLOOP_UTEXT", TypeOfToken = TokenType.FilesLoop, IsPaired = false, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true} }, 
             &    
             &    { new TokenMeta() {Name = "TAGLOOP_CONNECTOR_C", TypeOfToken = TokenType.TagLoop, IsPaired = false, Validity = TokenValidity.TagLoop, RequiresRepository = true} }, 
             &    { makeTokenMeta_UpperLower ("TAGLOOP_CONNECTOR_DBL", TokenType.TagLoop, TokenValidity.TagLoop, true) }, 
@@ -639,7 +659,7 @@ namespace CodeGen.Engine
             expressions.Add("ARRAY4_FIRST",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("ARRIVE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("ASCENDING",						TokenValidity.KeyLoop)
-            expressions.Add("ASCII",							TokenValidity.FileLoop)
+            expressions.Add("ASCII",							TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("AUTO_SEQUENCE",					TokenValidity.FieldLoop | TokenValidity.KeyLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("AUTO_TIMESTAMP",					TokenValidity.FieldLoop | TokenValidity.KeyLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("AUTO_TIMESTAMP_CREATED",			TokenValidity.FieldLoop | TokenValidity.KeyLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
@@ -657,7 +677,7 @@ namespace CodeGen.Engine
             expressions.Add("CANCELBUTTON",						TokenValidity.ButtonLoop)
             expressions.Add("CAPTION",							TokenValidity.ButtonLoop)
             expressions.Add("CHANGE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("CHANGE_TRACKING",					TokenValidity.FileLoop)
+            expressions.Add("CHANGE_TRACKING",					TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("CHANGES",							TokenValidity.KeyLoop)
             expressions.Add("CHECKBOX",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("COERCE",							TokenValidity.MethodLoop | TokenValidity.ParameterLoop)
@@ -733,7 +753,7 @@ namespace CodeGen.Engine
             expressions.Add("DECIMAL",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.MethodLoop | TokenValidity.ParameterLoop)
             expressions.Add("DEFAULT",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("DESCENDING",						TokenValidity.KeyLoop)
-            expressions.Add("DESCRIPTION",						TokenValidity.FieldLoop | TokenValidity.EnumLoop | TokenValidity.FileLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
+            expressions.Add("DESCRIPTION",						TokenValidity.FieldLoop | TokenValidity.EnumLoop | TokenValidity.FileLoop | TokenValidity.FilesLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("DESCRIPTOR",						TokenValidity.ParameterLoop)
             expressions.Add("DISABLED",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("DISPLAY",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
@@ -759,7 +779,7 @@ namespace CodeGen.Engine
             expressions.Add("FILE_STATIC_RFA",					TokenValidity.Anywhere)
             expressions.Add("FILE_STORED_GRFA",					TokenValidity.Anywhere)
             expressions.Add("FILE_TERABYTE",					TokenValidity.Anywhere)
-            expressions.Add("FIRST",							TokenValidity.FieldLoop | TokenValidity.FieldSelectionLoop | TokenValidity.ButtonLoop | TokenValidity.EnumLoop | TokenValidity.EnumMemberLoop | TokenValidity.FileLoop | TokenValidity.KeyLoop | TokenValidity.TagLoop | TokenValidity.RelationSegmentLoop)
+            expressions.Add("FIRST",							TokenValidity.FieldLoop | TokenValidity.FieldSelectionLoop | TokenValidity.ButtonLoop | TokenValidity.EnumLoop | TokenValidity.EnumMemberLoop | TokenValidity.FileLoop | TokenValidity.FilesLoop | TokenValidity.KeyLoop | TokenValidity.TagLoop | TokenValidity.RelationSegmentLoop | TokenValidity.StructureLoop)
             expressions.Add("FIRST_INSTANCE_OF_ENUM",			TokenValidity.ParameterLoop)
             expressions.Add("FIRST_INSTANCE_OF_STRUCTURE",		TokenValidity.ParameterLoop)
             expressions.Add("FIRST_SEG_NOCASE",					TokenValidity.KeyLoop)
@@ -785,6 +805,7 @@ namespace CodeGen.Engine
             expressions.Add("FROM_NULLKEY",						TokenValidity.RelationLoop)
             expressions.Add("FROM_NULLVALUE",					TokenValidity.RelationLoop)
             expressions.Add("FROM_SINGLE_SEGMENT",				TokenValidity.RelationLoop)
+            expressions.Add("FSLOOP_STRUCTURES",                TokenValidity.Anywhere)
             expressions.Add("FUNCTION",							TokenValidity.MethodLoop)
             expressions.Add("GENERICBUTTON",					TokenValidity.ButtonLoop)
             expressions.Add("GROUP_EXPAND",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
@@ -822,10 +843,10 @@ namespace CodeGen.Engine
             expressions.Add("INPUT_LEFT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("INPUT_RIGHT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("INTEGER",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.MethodLoop | TokenValidity.ParameterLoop)
-            expressions.Add("ISAM",								TokenValidity.FileLoop)
+            expressions.Add("ISAM",								TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("KEYSEGMENT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("LANGUAGE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("LAST",								TokenValidity.FieldLoop | TokenValidity.FieldSelectionLoop | TokenValidity.TagLoop)
+            expressions.Add("LAST",								TokenValidity.FieldLoop | TokenValidity.FieldSelectionLoop | TokenValidity.TagLoop | TokenValidity.StructureLoop)
             expressions.Add("LEAVE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("LENGTH_OVER_8",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("LONG_DESCRIPTION",					TokenValidity.EnumLoop)
@@ -848,12 +869,12 @@ namespace CodeGen.Engine
             expressions.Add("NOARRIVE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOBREAK",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOCHANGE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOCHANGE_TRACKING",				TokenValidity.FileLoop)
+            expressions.Add("NOCHANGE_TRACKING",				TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOCHANGES",						TokenValidity.KeyLoop)
             expressions.Add("NOCHECKBOX",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOCOERCEBOOLEAN",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NODEFAULT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NODESCRIPTION",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.FileLoop)
+            expressions.Add("NODESCRIPTION",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NODISPLAY",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NODISPLAY_LENGTH",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NODRILL",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
@@ -875,17 +896,17 @@ namespace CodeGen.Engine
             expressions.Add("NOPRECISION",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOPROMPT",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NORANGE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NORECORDCOMPRESSION",				TokenValidity.FileLoop)
+            expressions.Add("NORECORDCOMPRESSION",				TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOREPORT",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOSELECTIONS",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOSELWND",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOSTORED_GRFA",					TokenValidity.FileLoop)
+            expressions.Add("NOSTORED_GRFA",					TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOT_COUNTER_1",					TokenValidity.Anywhere)
             expressions.Add("NOT_COUNTER_2",					TokenValidity.Anywhere)
             expressions.Add("NOT_USERTOKEN_",					TokenValidity.Anywhere)
             expressions.Add("NOTALPHA",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTARRAY",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOTASCII",							TokenValidity.FileLoop)
+            expressions.Add("NOTASCII",							TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOTBINARY",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTBOOLEAN",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTBZERO",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
@@ -897,26 +918,26 @@ namespace CodeGen.Engine
             expressions.Add("NOTENUMERATED",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTIMEOUT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTINTEGER",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOTISAM",							TokenValidity.FileLoop)
+            expressions.Add("NOTISAM",							TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOTKEYSEGMENT",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTNUMERIC",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTOOLKIT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTOVERLAY",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTPKSEGMENT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTRADIOBUTTONS",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOTRECORDTYPEFIXED",				TokenValidity.FileLoop)
-            expressions.Add("NOTRECORDTYPEMULTIPLE",			TokenValidity.FileLoop)
-            expressions.Add("NOTRECORDTYPEVARIABLE",			TokenValidity.FileLoop)
-            expressions.Add("NOTRELATIVE",						TokenValidity.FileLoop)
-            expressions.Add("NOTSTATICRFA",						TokenValidity.FileLoop)
+            expressions.Add("NOTRECORDTYPEFIXED",				TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("NOTRECORDTYPEMULTIPLE",			TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("NOTRECORDTYPEVARIABLE",			TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("NOTRELATIVE",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("NOTSTATICRFA",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOTSTRUCTFIELD",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOTTERABYTE",						TokenValidity.FileLoop)
+            expressions.Add("NOTTERABYTE",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOTTIME",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTUPPERCASE",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOTUSER",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOTUSERDEFINED",					TokenValidity.FileLoop)
+            expressions.Add("NOTUSERDEFINED",					TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOTUSERTIMESTAMP",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("NOUSERTEXT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.FileLoop)
+            expressions.Add("NOUSERTEXT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("NOVIEW_LENGTH",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NOWEB",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("NULLKEY",							TokenValidity.KeyLoop)
@@ -930,13 +951,13 @@ namespace CodeGen.Engine
             expressions.Add("OUT",								TokenValidity.MethodLoop | TokenValidity.ParameterLoop)
             expressions.Add("OUT_OR_INOUT",						TokenValidity.MethodLoop | TokenValidity.ParameterLoop)
             expressions.Add("OVERLAY",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("PAGESIZE1024",						TokenValidity.FileLoop)
-            expressions.Add("PAGESIZE16384",					TokenValidity.FileLoop)
-            expressions.Add("PAGESIZE2048",						TokenValidity.FileLoop)
-            expressions.Add("PAGESIZE32768",					TokenValidity.FileLoop)
-            expressions.Add("PAGESIZE4096",						TokenValidity.FileLoop)
-            expressions.Add("PAGESIZE8192",						TokenValidity.FileLoop)
-            expressions.Add("PAGESIZE512",						TokenValidity.FileLoop)
+            expressions.Add("PAGESIZE1024",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("PAGESIZE16384",					TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("PAGESIZE2048",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("PAGESIZE32768",					TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("PAGESIZE4096",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("PAGESIZE8192",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("PAGESIZE512",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("PAINTCHAR",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("PARAMETERS",						TokenValidity.MethodLoop)
             expressions.Add("PKSEGMENT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
@@ -948,12 +969,12 @@ namespace CodeGen.Engine
             expressions.Add("RANGE",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("READONLY",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("READWRITE",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("RECORDCOMPRESSION",				TokenValidity.FileLoop)
-            expressions.Add("RECORDTYPEFIXED",					TokenValidity.FileLoop)
-            expressions.Add("RECORDTYPEMULTIPLE",				TokenValidity.FileLoop)
-            expressions.Add("RECORDTYPEVARIABLE",				TokenValidity.FileLoop)
+            expressions.Add("RECORDCOMPRESSION",				TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("RECORDTYPEFIXED",					TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("RECORDTYPEMULTIPLE",				TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("RECORDTYPEVARIABLE",				TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("REFERENCE",						TokenValidity.ParameterLoop)
-            expressions.Add("RELATIVE",							TokenValidity.FileLoop)
+            expressions.Add("RELATIVE",							TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("REPORT",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("REPORT_CENTER",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("REPORT_LEFT",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
@@ -981,8 +1002,8 @@ namespace CodeGen.Engine
             expressions.Add("SELWND",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("SINGLE_SEGMENT",					TokenValidity.KeyLoop)
             expressions.Add("SINGLE_TAG",						TokenValidity.TagLoop)
-            expressions.Add("STATICRFA",						TokenValidity.FileLoop)
-            expressions.Add("STORED_GRFA",						TokenValidity.FileLoop)
+            expressions.Add("STATICRFA",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("STORED_GRFA",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("STRING",							TokenValidity.MethodLoop | TokenValidity.ParameterLoop)
             expressions.Add("STRUCTFIELD",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("STRUCTURE",						TokenValidity.ParameterLoop)
@@ -1003,7 +1024,7 @@ namespace CodeGen.Engine
             expressions.Add("STRUCTURE_USER_DEFINED",			TokenValidity.Anywhere)
             expressions.Add("STRUCTURE_UTEXT",					TokenValidity.Anywhere)
             expressions.Add("SUBROUTINE",						TokenValidity.MethodLoop)
-            expressions.Add("TERABYTE",							TokenValidity.FileLoop)
+            expressions.Add("TERABYTE",							TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("TEXTBOX",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("TIME",								TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.ParameterLoop)
             expressions.Add("TIME_HHMM",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.ParameterLoop)
@@ -1036,8 +1057,8 @@ namespace CodeGen.Engine
             expressions.Add("UNDERLINE",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("UPPERCASE",						TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("USER",								TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
-            expressions.Add("USERDEFINED",						TokenValidity.FileLoop)
-            expressions.Add("USERTEXT",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.FileLoop)
+            expressions.Add("USERDEFINED",						TokenValidity.FileLoop | TokenValidity.FilesLoop)
+            expressions.Add("USERTEXT",							TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop | TokenValidity.FileLoop | TokenValidity.FilesLoop)
             expressions.Add("USERTIMESTAMP",					TokenValidity.FieldLoop | TokenValidity.KeySegmentLoop | TokenValidity.RelationSegmentLoop)
             expressions.Add("USERTOKEN_",						TokenValidity.Anywhere)
             expressions.Add("VALUE",							TokenValidity.ParameterLoop)
@@ -2133,6 +2154,18 @@ namespace CodeGen.Engine
                             addLookupToken(makeTokenMeta_UpperLower(customexpander.Item1, TokenType.FileLoop, TokenValidity.FileLoop, true))
                         (TokenCaseMode.UppercaseOnly),
                             addLookupToken(new TokenMeta() {Name = customexpander.Item1, TypeOfToken = TokenType.FileLoop, Validity = TokenValidity.FileLoop, RequiresRepository = true})
+                        endusing
+                    end
+
+                    (TokenValidity.FilesLoop),
+                    begin
+                        using (customexpander.Item4) select
+                        (TokenCaseMode.AllCasingOptions),
+                            addLookupToken(makeTokenMeta_AllVariants(customexpander.Item1, TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true))
+                        (TokenCaseMode.UppercaseAndLowerCase),
+                            addLookupToken(makeTokenMeta_UpperLower(customexpander.Item1, TokenType.FilesLoop, TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, true))
+                        (TokenCaseMode.UppercaseOnly),
+                            addLookupToken(new TokenMeta() {Name = customexpander.Item1, TypeOfToken = TokenType.FilesLoop, Validity = TokenValidity.FilesLoop | TokenValidity.FilesFirstMode, RequiresRepository = true})
                         endusing
                     end
 

--- a/CodeGenEngine/TreeExpander.dbl
+++ b/CodeGenEngine/TreeExpander.dbl
@@ -382,7 +382,9 @@ namespace CodeGen.Engine
 						validLocations.Add(TokenType.ButtonLoop)
 					(TokenValidity.FileLoop),
 						validLocations.Add(TokenType.FileLoop)
-					(TokenValidity.TagLoop),
+                    (TokenValidity.FilesLoop),
+                        validLocations.Add(TokenType.FilesLoop)
+                    (TokenValidity.TagLoop),
 						validLocations.Add(TokenType.TagLoop)
 					(TokenValidity.InterfaceLoop),
 						validLocations.Add(TokenType.InterfaceLoop)

--- a/CodeGenEngine/TreeLogger.dbl
+++ b/CodeGenEngine/TreeLogger.dbl
@@ -96,10 +96,11 @@ namespace CodeGen.Engine
             node, @FileNode 
         proc
             ;; Write the structure of the tree to a file
-			disposable data sw, @StreamWriter, File.CreateText(logFile)
+			sw = File.CreateText(logFile)
 			currentFileNode = node
 			Visit(node.Body)
-			sw.Close()
+            sw.Close()
+            sw.Dispose()
 		endmethod
 
         public method Visit, void

--- a/CodeGenEngine/TreeNodes.dbl
+++ b/CodeGenEngine/TreeNodes.dbl
@@ -181,6 +181,13 @@ namespace CodeGen.Engine
         public CurrentFile, @RpsFile
     endclass
 
+    ;;; <summary>
+    ;;; Represents a files loop token in a template file.
+    ;;; </summary>
+    public class FilesLoopNode extends LoopNode
+        public CurrentFile, @RpsFile
+    endclass
+
 	;;; <summary>
 	;;; Represents a tag loop token in a template file.
 	;;; </summary>

--- a/RepositoryAPI/RpsFile.dbl
+++ b/RepositoryAPI/RpsFile.dbl
@@ -59,6 +59,7 @@ namespace CodeGen.RepositoryAPI
 		
 		;;File attribute data
         protected mfl_info          ,fl_info
+        protected mfls_info         ,fls_info
         protected mKeys             ,@RpsKeyCollection
         protected mStructures       ,@RpsStructureCollection
 		protected mStructureNames	,@List<string>
@@ -140,6 +141,8 @@ namespace CodeGen.RepositoryAPI
 				data strNames,  D_HANDLE, %mem_proc(DM_ALLOC,^size(strIdentifier)*mfl_info.fli_nmstructs)
 				data odbcNames, D_HANDLE, %mem_proc(DM_ALLOC,^size(strIdentifier)*mfl_info.fli_nmstructs)
 				
+                xcall dd_filespec(Repository.RpsControl,this.Name,,^a(mfls_info))
+                
 				xcall dd_file(Repository.RpsControl,DDL_STRS,mfl_info.fli_nmstructs,^m(strIdentifier,strNames),,,^m(strIdentifier,odbcNames))
 
 				data strName, string
@@ -232,6 +235,14 @@ namespace CodeGen.RepositoryAPI
             endmethod
         endproperty
 
+        ;;Record size?
+        public property RecordSize, int
+            method get
+            proc
+                mreturn mfls_info.flsi_recsz
+            endmethod
+        endproperty
+        
         ;; Record type (enum RpsRecordType)
         ;; FixedLength, 0
         ;; VariableLength, 1

--- a/RepositoryAPI/RpsFileCollection.dbl
+++ b/RepositoryAPI/RpsFileCollection.dbl
@@ -120,6 +120,33 @@ namespace CodeGen.RepositoryAPI
             endtry
         endmethod
 
+        public method Merge, void
+            required in StructureFiles, @RpsFileCollection
+            endparams
+
+            record local_data
+                file1, @RpsFile
+                file2, @RpsFile
+                str1, @RpsStructure
+                str2, @RpsStructure
+                found, boolean
+        proc
+            found = false
+            foreach file1 in StructureFiles
+            begin
+                foreach file2 in this
+                begin
+                    if (file1.Name.Equals(file2.Name))
+                        found = true
+                end
+
+                if (!found)
+                begin
+                    Add(file1)
+                end
+            end
+        endmethod
+
         ;; Load structure Files
         private method LoadStructureFiles, void
             required in StructureName, String

--- a/UnitTests/Tokenizer_ExpansionTokens.dbl
+++ b/UnitTests/Tokenizer_ExpansionTokens.dbl
@@ -221,7 +221,14 @@ namespace UnitTests
 			Assert.IsTrue(tokenizeExpansionToken("FILE_PAGESIZE",TokenType.StructureInfo))
 		endmethod
 		
-		{TestMethod}
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method StructureFileRecordSize, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FILE_RECORDSIZE",TokenType.StructureInfo))
+        endmethod
+		
+        {TestMethod}
 		{TestCategory("Tokenizer - Expansion Tokens")}
 		public method StructureFileRecType, void
 		proc
@@ -1387,7 +1394,14 @@ namespace UnitTests
 			Assert.IsTrue(tokenizeExpansionToken("FLOOP_PAGESIZE",TokenType.FileLoop))
 		endmethod
 		
-		{TestMethod}
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FileLoopRecordSize, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FLOOP_RECORDSIZE",TokenType.FileLoop))
+        endmethod
+		
+        {TestMethod}
 		{TestCategory("Tokenizer - Expansion Tokens")}
 		public method FileLoopRecType, void
 		proc
@@ -1424,6 +1438,108 @@ namespace UnitTests
 		
 .endregion
 		
+.region "File loop tokens"
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopAddressing, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_ADDRESSING",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopChangeTracking, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_CHANGE_TRACKING",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopCompression, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_COMPRESSION",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopDensity, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_DENSITY",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopDesc, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_DESC",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopName, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_NAME",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopNameNoExt, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_NAME_NOEXT",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopPageSize, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_PAGESIZE",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopRecordSize, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_RECORDSIZE",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopRecType, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_RECTYPE",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopStaticRfa, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_STATIC_RFA",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopStoredGrfa, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_STORED_GRFA",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopType, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_TYPE",TokenType.FilesLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expansion Tokens")}
+        public method FilesLoopUserText, void
+        proc
+            Assert.IsTrue(tokenizeExpansionToken("FSLOOP_UTEXT",TokenType.FilesLoop))
+        endmethod
+		
+.endregion
+
 .region "Button loop tokens"
 		
 		{TestMethod}

--- a/UnitTests/Tokenizer_Expressions.dbl
+++ b/UnitTests/Tokenizer_Expressions.dbl
@@ -580,12 +580,33 @@ namespace UnitTests
 		proc
 			Assert.IsTrue(tokenizeExpression("LANGUAGE",TokenValidity.FieldLoop))
 		endmethod
+        
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FieldLoopExpressionLAST, void
+        proc
+            Assert.IsTrue(tokenizeExpression("LAST",TokenValidity.FieldLoop))
+        endmethod
 		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FilesLoopExpressionLAST, void
+        proc
+        Assert.IsTrue(tokenizeExpression("LAST",TokenValidity.FilesLoop))
+        endmethod
+				
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionLAST, void
+        proc
+            Assert.IsTrue(tokenizeExpression("LAST",TokenValidity.FileLoop))
+        endmethod
+				
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FieldLoopExpressionLAST, void
+		public method StructureLoopExpressionLAST, void
 		proc
-			Assert.IsTrue(tokenizeExpression("LAST",TokenValidity.FieldLoop))
+			Assert.IsTrue(tokenizeExpression("LAST",TokenValidity.StructureLoop))
 		endmethod
 		
 		{TestMethod}
@@ -2908,259 +2929,522 @@ namespace UnitTests
 		endmethod
 		
 .endregion
-		
+ 
 .region "File Loop Expressions"
 		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionASCII, void
+        proc
+            Assert.IsTrue(tokenizeExpression("ASCII",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionCHANGE_TRACKING, void
+        proc
+            Assert.IsTrue(tokenizeExpression("CHANGE_TRACKING",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionDESCRIPTION, void
+        proc
+            Assert.IsTrue(tokenizeExpression("DESCRIPTION",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionFIRST, void
+        proc
+            Assert.IsTrue(tokenizeExpression("FIRST",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionISAM, void
+        proc
+            Assert.IsTrue(tokenizeExpression("ISAM",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOCHANGE_TRACKING, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOCHANGE_TRACKING",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNODESCRIPTION, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NODESCRIPTION",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNORECORDCOMPRESSION, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NORECORDCOMPRESSION",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOSTORED_GRFA, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOSTORED_GRFA",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTASCII, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTASCII",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTISAM, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTISAM",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTRECORDTYPEFIXED, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEFIXED",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTRECORDTYPEMULTIPLE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEMULTIPLE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTRECORDTYPEVARIABLE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEVARIABLE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTRELATIVE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTRELATIVE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTSTATICRFA, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTSTATICRFA",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTTERABYTE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTTERABYTE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOTUSERDEFINED, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOTUSERDEFINED",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionNOUSERTEXT, void
+        proc
+            Assert.IsTrue(tokenizeExpression("NOUSERTEXT",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionPAGESIZE1024, void
+        proc
+            Assert.IsTrue(tokenizeExpression("PAGESIZE1024",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionPAGESIZE16384, void
+        proc
+            Assert.IsTrue(tokenizeExpression("PAGESIZE16384",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionPAGESIZE2048, void
+        proc
+            Assert.IsTrue(tokenizeExpression("PAGESIZE2048",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionPAGESIZE32768, void
+        proc
+            Assert.IsTrue(tokenizeExpression("PAGESIZE32768",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionPAGESIZE4096, void
+        proc
+            Assert.IsTrue(tokenizeExpression("PAGESIZE4096",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionPAGESIZE512, void
+        proc
+            Assert.IsTrue(tokenizeExpression("PAGESIZE512",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionPAGESIZE8192, void
+        proc
+            Assert.IsTrue(tokenizeExpression("PAGESIZE8192",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionRECORDCOMPRESSION, void
+        proc
+            Assert.IsTrue(tokenizeExpression("RECORDCOMPRESSION",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionRECORDTYPEFIXED, void
+        proc
+            Assert.IsTrue(tokenizeExpression("RECORDTYPEFIXED",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionRECORDTYPEMULTIPLE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("RECORDTYPEMULTIPLE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionRECORDTYPEVARIABLE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("RECORDTYPEVARIABLE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionRELATIVE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("RELATIVE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionSTATICRFA, void
+        proc
+            Assert.IsTrue(tokenizeExpression("STATICRFA",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionSTORED_GRFA, void
+        proc
+            Assert.IsTrue(tokenizeExpression("STORED_GRFA",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionTERABYTE, void
+        proc
+            Assert.IsTrue(tokenizeExpression("TERABYTE",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionUSERDEFINED, void
+        proc
+            Assert.IsTrue(tokenizeExpression("USERDEFINED",TokenValidity.FileLoop))
+        endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method FileLoopExpressionUSERTEXT, void
+        proc
+            Assert.IsTrue(tokenizeExpression("USERTEXT",TokenValidity.FileLoop))
+        endmethod
+		
+.endregion
+		        
+.region "Files Loop Expressions"
+		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionASCII, void
+		public method FilesLoopExpressionASCII, void
 		proc
-			Assert.IsTrue(tokenizeExpression("ASCII",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("ASCII",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionCHANGE_TRACKING, void
+		public method FilesLoopExpressionCHANGE_TRACKING, void
 		proc
-			Assert.IsTrue(tokenizeExpression("CHANGE_TRACKING",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("CHANGE_TRACKING",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionDESCRIPTION, void
+		public method FilesLoopExpressionDESCRIPTION, void
 		proc
-			Assert.IsTrue(tokenizeExpression("DESCRIPTION",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("DESCRIPTION",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionFIRST, void
+		public method FilesLoopExpressionFIRST, void
 		proc
-			Assert.IsTrue(tokenizeExpression("FIRST",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("FIRST",TokenValidity.FilesLoop))
+		endmethod
+		
+        {TestMethod}
+        {TestCategory("Tokenizer - Expressions")}
+        public method StructureLoopExpressionFIRST, void
+        proc
+            Assert.IsTrue(tokenizeExpression("FIRST",TokenValidity.StructureLoop))
+        endmethod
+		
+        {TestMethod}
+		{TestCategory("Tokenizer - Expressions")}
+		public method FilesLoopExpressionISAM, void
+		proc
+			Assert.IsTrue(tokenizeExpression("ISAM",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionISAM, void
+		public method FilesLoopExpressionNOCHANGE_TRACKING, void
 		proc
-			Assert.IsTrue(tokenizeExpression("ISAM",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOCHANGE_TRACKING",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOCHANGE_TRACKING, void
+		public method FilesLoopExpressionNODESCRIPTION, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOCHANGE_TRACKING",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NODESCRIPTION",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNODESCRIPTION, void
+		public method FilesLoopExpressionNORECORDCOMPRESSION, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NODESCRIPTION",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NORECORDCOMPRESSION",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNORECORDCOMPRESSION, void
+		public method FilesLoopExpressionNOSTORED_GRFA, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NORECORDCOMPRESSION",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOSTORED_GRFA",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOSTORED_GRFA, void
+		public method FilesLoopExpressionNOTASCII, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOSTORED_GRFA",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTASCII",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTASCII, void
+		public method FilesLoopExpressionNOTISAM, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTASCII",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTISAM",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTISAM, void
+		public method FilesLoopExpressionNOTRECORDTYPEFIXED, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTISAM",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEFIXED",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTRECORDTYPEFIXED, void
+		public method FilesLoopExpressionNOTRECORDTYPEMULTIPLE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEFIXED",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEMULTIPLE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTRECORDTYPEMULTIPLE, void
+		public method FilesLoopExpressionNOTRECORDTYPEVARIABLE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEMULTIPLE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEVARIABLE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTRECORDTYPEVARIABLE, void
+		public method FilesLoopExpressionNOTRELATIVE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTRECORDTYPEVARIABLE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTRELATIVE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTRELATIVE, void
+		public method FilesLoopExpressionNOTSTATICRFA, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTRELATIVE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTSTATICRFA",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTSTATICRFA, void
+		public method FilesLoopExpressionNOTTERABYTE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTSTATICRFA",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTTERABYTE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTTERABYTE, void
+		public method FilesLoopExpressionNOTUSERDEFINED, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTTERABYTE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOTUSERDEFINED",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOTUSERDEFINED, void
+		public method FilesLoopExpressionNOUSERTEXT, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOTUSERDEFINED",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("NOUSERTEXT",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionNOUSERTEXT, void
+		public method FilesLoopExpressionPAGESIZE1024, void
 		proc
-			Assert.IsTrue(tokenizeExpression("NOUSERTEXT",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("PAGESIZE1024",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionPAGESIZE1024, void
+		public method FilesLoopExpressionPAGESIZE16384, void
 		proc
-			Assert.IsTrue(tokenizeExpression("PAGESIZE1024",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("PAGESIZE16384",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionPAGESIZE16384, void
+		public method FilesLoopExpressionPAGESIZE2048, void
 		proc
-			Assert.IsTrue(tokenizeExpression("PAGESIZE16384",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("PAGESIZE2048",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionPAGESIZE2048, void
+		public method FilesLoopExpressionPAGESIZE32768, void
 		proc
-			Assert.IsTrue(tokenizeExpression("PAGESIZE2048",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("PAGESIZE32768",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionPAGESIZE32768, void
+		public method FilesLoopExpressionPAGESIZE4096, void
 		proc
-			Assert.IsTrue(tokenizeExpression("PAGESIZE32768",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("PAGESIZE4096",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionPAGESIZE4096, void
+		public method FilesLoopExpressionPAGESIZE512, void
 		proc
-			Assert.IsTrue(tokenizeExpression("PAGESIZE4096",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("PAGESIZE512",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionPAGESIZE512, void
+		public method FilesLoopExpressionPAGESIZE8192, void
 		proc
-			Assert.IsTrue(tokenizeExpression("PAGESIZE512",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("PAGESIZE8192",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionPAGESIZE8192, void
+		public method FilesLoopExpressionRECORDCOMPRESSION, void
 		proc
-			Assert.IsTrue(tokenizeExpression("PAGESIZE8192",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("RECORDCOMPRESSION",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionRECORDCOMPRESSION, void
+		public method FilesLoopExpressionRECORDTYPEFIXED, void
 		proc
-			Assert.IsTrue(tokenizeExpression("RECORDCOMPRESSION",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("RECORDTYPEFIXED",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionRECORDTYPEFIXED, void
+		public method FilesLoopExpressionRECORDTYPEMULTIPLE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("RECORDTYPEFIXED",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("RECORDTYPEMULTIPLE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionRECORDTYPEMULTIPLE, void
+		public method FilesLoopExpressionRECORDTYPEVARIABLE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("RECORDTYPEMULTIPLE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("RECORDTYPEVARIABLE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionRECORDTYPEVARIABLE, void
+		public method FilesLoopExpressionRELATIVE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("RECORDTYPEVARIABLE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("RELATIVE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionRELATIVE, void
+		public method FilesLoopExpressionSTATICRFA, void
 		proc
-			Assert.IsTrue(tokenizeExpression("RELATIVE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("STATICRFA",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionSTATICRFA, void
+		public method FilesLoopExpressionSTORED_GRFA, void
 		proc
-			Assert.IsTrue(tokenizeExpression("STATICRFA",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("STORED_GRFA",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionSTORED_GRFA, void
+		public method FilesLoopExpressionTERABYTE, void
 		proc
-			Assert.IsTrue(tokenizeExpression("STORED_GRFA",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("TERABYTE",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionTERABYTE, void
+		public method FilesLoopExpressionUSERDEFINED, void
 		proc
-			Assert.IsTrue(tokenizeExpression("TERABYTE",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("USERDEFINED",TokenValidity.FilesLoop))
 		endmethod
 		
 		{TestMethod}
 		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionUSERDEFINED, void
+		public method FilesLoopExpressionUSERTEXT, void
 		proc
-			Assert.IsTrue(tokenizeExpression("USERDEFINED",TokenValidity.FileLoop))
-		endmethod
-		
-		{TestMethod}
-		{TestCategory("Tokenizer - Expressions")}
-		public method FileLoopExpressionUSERTEXT, void
-		proc
-			Assert.IsTrue(tokenizeExpression("USERTEXT",TokenValidity.FileLoop))
+			Assert.IsTrue(tokenizeExpression("USERTEXT",TokenValidity.FilesLoop))
 		endmethod
 		
 .endregion


### PR DESCRIPTION
Adds new loop FILES_LOOP, designed to be used above structures (different to FILE_LOOP) and FSLOOP_* expressions/expanders/etc

- Adds FLOOP_RECORDSIZE, FSLOOP_RECORDSIZE, FILE_RECORDSIZE to get the actually file structure size
- Adds new files first parameter (-ff) to start down files not structures
- Fixes issue where <IF FIRST> can claim to be invalid because a text node follows it
- Fixes issue where <IF FIRST> can't be used in a structure loop
- Fixes issue where TreeLogger tries to write to a streamwriter that does not exist
- Adds RecordSize to RpsFile
- Adds Merge() to RpsFileCollection
- Adds various UnitTests