### PR TITLE
Fixed code generation looping through a template multiple times

### DIFF
--- a/CodeGenEngine/CodeGenerator.dbl
+++ b/CodeGenEngine/CodeGenerator.dbl
@@ -1893,8 +1893,8 @@ namespace CodeGen.Engine
                                     ;;Generate the code
                                     errStatus = expandTreeToCode(tree)
                                 end
-                                ;;Bail structure loop on failure?
-                                if ((errStatus) && (!context.Taskset.ContinueAfterError))
+                                ;;Bail structure loop on failure or there's only one template to process
+                                if (((errStatus) && (!context.Taskset.ContinueAfterError)) || context.TemplateFiles.Count <= 1)
                                     exitloop
                             end
                         end


### PR DESCRIPTION
Fixes the issue where a single command would generate multiples of the same file.

Example:
```
codegen -smcstrs xfplSMC\strtests.xml -interface strtests -t C:\Users\devadm\Desktop\HarmonyCore\Templates\TraditionalBridge\MultiInterfaceServiceModels -i Templates\TraditionalBridge -o C:\Users\devadm\Desktop\HarmonyCore\TraditionalBridge.TestClient\Client -n TraditionalBridge.TestClient -ut MODELS_NAMESPACE=TraditionalBridge.Models DTOS_NAMESPACE=TraditionalBridge.TestClient.strtests -e -r -lf

Task complete, 27 files generated.

 - strtestsServiceModels.dbl
 - strtestsServiceModels.dbl
...
 - strtestsServiceModels.dbl
```

This is stemming from the fact that `strtests.xml` has 27 structures inside of it.
They all get looked at during the first pass of the loop. The 26 other loops are unnecessary, and all generate the same code.

@SteveIves I'm pretty sure this change has no repercussions as I tested this with HarmonyCore regen and it worked without issues. Do you have anything to add?