### PR TITLE
Failed import of wix.ca.targets on fresh dev node

### DIFF
--- a/CodeGenSetupCustomActions/CodeGenSetupCustomActions.synproj
+++ b/CodeGenSetupCustomActions/CodeGenSetupCustomActions.synproj
@@ -20,7 +20,6 @@
     <Language>Synergy</Language>
     <DBL_unQulRecStm>Stack</DBL_unQulRecStm>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-    <WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' ">C:\Program Files\MSBuild\Microsoft\WiX\wix.ca.targets</WixCATargetsPath>
     <EnableCommonProperties>True</EnableCommonProperties>
     <StartupObject>(Not set)</StartupObject>
     <ResourceType>Icon</ResourceType>
@@ -79,7 +78,8 @@
     <Folder Include="Properties" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Synergex\VS2010\Synergex.SynergyDE.targets" />
-  <Import Project="$(WixCATargetsPath)" Condition="'$(WixCATargetsPath)' != ''" />
+  <Import Project="$(WixCATargetsPath)" Condition=" '$(WixCATargetsPath)' != '' AND Exists('$(WixCATargetsPath)')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.ca.targets" Condition=" '$(WixCATargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.ca.targets')" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>


### PR DESCRIPTION
The CustomActions project in CodeGen has a hard-coded path to 64-bit Program Files\MSBuild. This location lacks the appropriate WiX.CA.targets file and is generally not portable.

This PR changes the WiX.CA.targets import to use portable MSBuild variables and performs standard existence checks. An alternate import, with existence checks, of WixCATargetsPath is left in for user-override capability.