### PR TITLE
Improve error text for invalid interface tokens

### DIFF
--- a/CodeGenEngine/CodeGenerator.dbl
+++ b/CodeGenEngine/CodeGenerator.dbl
@@ -1983,18 +1983,18 @@ namespace CodeGen.Engine
                     ;;Interface loop tolens are probably OK, because -interface can be used with -smcstrs.
                     if (context.CurrentTask.MethodCatalogStructureMode)
                     begin
-                        data problem = false
+                        data badToken, @Token, ^null
                         if (String.IsNullOrWhiteSpace(context.CurrentTask.MethodCatalogInterface)) then
                         begin
-                            problem = tokens.Any(lambda(tkn) { tkn.TypeOfToken == TokenType.InterfaceLoop || tkn.TypeOfToken == TokenType.MethodLoop || tkn.TypeOfToken == TokenType.ParameterLoop })
+                            badToken = tokens.FirstOrDefault(lambda(tkn) { tkn.TypeOfToken == TokenType.InterfaceLoop || tkn.TypeOfToken == TokenType.MethodLoop || tkn.TypeOfToken == TokenType.ParameterLoop })
                         end
                         else
                         begin
-                            problem = tokens.Any(lambda(tkn) { tkn.TypeOfToken == TokenType.MethodLoop || tkn.TypeOfToken == TokenType.ParameterLoop })
+                            badToken = tokens.FirstOrDefault(lambda(tkn) { tkn.TypeOfToken == TokenType.MethodLoop || tkn.TypeOfToken == TokenType.ParameterLoop })
                         end
-                        if (problem)
+                        if (badToken != ^null)
                         begin
-                            errStatus = context.CurrentTask.ErrorLog(String.Format("Template {0} contains method catalog tokens that may not be used when processing repository structures!",Path.GetFileName(context.CurrentTemplate)))
+                            errStatus = context.CurrentTask.ErrorLog(String.Format("Template {0} contains at least one method catalog token that may not be used when processing repository structures! The first seen token was {1}",Path.GetFileName(context.CurrentTemplate), badToken.ToString()))
                             nextloop
                         end
                     end


### PR DESCRIPTION
Output the details for the first invalid token we see. This should give the user at least some indication of whats gone wrong.