### PR TITLE
CreateFile index fix

### DIFF
--- a/CreateFile/CreateFile.dbl
+++ b/CreateFile/CreateFile.dbl
@@ -52,7 +52,7 @@ namespace CreateFile
     main CreateFile
 
         .define APP_NAME        "CreateFile"
-        .define APP_VERSION     "V2.0"
+        .define APP_VERSION     "V2.1"
 
         .include "RPSLIB:ddinfo.def"
 
@@ -63,6 +63,8 @@ namespace CreateFile
             strname,        String      ;Structure to process
             inpfile,        String      ;Input instructions file name
             filespec,       String      ;File to create
+	    rpsmfil,	    String      ;Explicit RPS Main File
+	    rpstfil,	    String      ;Explicit RPS Text File
             filecreated,    String      ;File created
             errtxt,         String      ;Error text
             replace,        boolean     ;Replace existing files?
@@ -199,12 +201,48 @@ namespace CreateFile
             replace = CommandLineParser.Parse("r")
         end
 
+	;---------------------------------------------------------------------------
+	;Check for a repository main file option
+
+	if (ok)
+	begin
+	    rpsmfil = ""
+	    if (CommandLineParser.Parse("rm",clvalues))
+	    begin
+		if (clvalues.Count) then
+		    rpsmfil = clvalues[0]
+		else
+		begin
+		    Console.WriteLine("No file specification found after the -rm option, use -h for help!")
+		    ok = false
+		end
+	    end
+	end
+
+	;---------------------------------------------------------------------------
+	;Check for a repository text file option
+
+	if (ok)
+	begin
+	    rpstfil = ""
+	    if (CommandLineParser.Parse("rt",clvalues))
+	    begin
+		if (clvalues.Count) then
+		    rpstfil = clvalues[0]
+		else
+		begin
+		    Console.WriteLine("No file specification found after the -rt option, use -h for help!")
+		    ok = false
+		end
+	    end
+	end
+
         ;---------------------------------------------------------------------------
         ;Open the repository
 
         if (ok)
         begin
-            xcall dd_init(dcs)
+            xcall dd_init(dcs, rpsmfil, rpstfil)
             if (dcs.error) then
             begin
                 Console.WriteLine("Failed to open repository!")
@@ -260,7 +298,8 @@ namespace CreateFile
 
         ;Limit for text    -------------------------------------------------------------------------------
         Console.WriteLine('')
-        Console.WriteLine('  CreateFile -f <fname> | -s <sname> [-out <filespec>] [-r] [-h]')
+        Console.WriteLine('  CreateFile -f <fname> | -s <sname> | -in <infile>')
+	Console.WriteLine('          [-out <filespec>] [-r] [-rm <rpsmfil> -rt <rpstfil>] [-h]')
         Console.WriteLine('')
         Console.WriteLine('    -f <fname>')
         Console.WriteLine('          Name of repository file definition to process')
@@ -273,17 +312,25 @@ namespace CreateFile
         Console.WriteLine('')
         Console.WriteLine('    -out <filespec>')
         Console.WriteLine('          File spec of file to create, overriding repository file spec')
-        Console.WriteLine('          Not used with -in.')
+        Console.WriteLine('          Not used with -in. If used with -s for a structure that is not ')
+	Console.WriteLine('          assigned to any files, this will override the error message and ')
+	Console.WriteLine('          create the specified file with a warning.')
         Console.WriteLine('')
         Console.WriteLine('    -r    Replace existing files. The default is not to replace existing files.')
         Console.WriteLine('          Not used with -in.')
         Console.WriteLine('')
+	Console.WriteLine('    -rm <rpsmfil> -rt <rpstfil>')
+	Console.WriteLine('          Names of repository main file and text file, overriding repository')
+	Console.WriteLine('          from environment')
+	Console.WriteLine('          Not used with -in.')
+	Console.WriteLine('')
         Console.WriteLine('    -h    Display this usage information')
         Console.WriteLine('')
         Console.WriteLine('  The -f and -s options can only be used to create ISAM files.')
         Console.WriteLine('')
-        Console.WriteLine('  The -in option can be used to create ISAM and RELATIVE files, but RELATIVE files')
-        Console.WriteLine('  can only be created if an input file containing initial data is provided.')
+        Console.WriteLine('  The -in option can be used to create ISAM and RELATIVE files, but RELATIVE ')
+        Console.WriteLine('  files can only be created if an input file containing initial data is ')
+	Console.WriteLine('  provided.')
         Console.WriteLine('')
         Console.WriteLine('  The input file used with the -in option must be a JSON file similar to this:')
         Console.WriteLine('')
@@ -302,12 +349,13 @@ namespace CreateFile
         Console.WriteLine('    }')
         Console.WriteLine('  ]')
         Console.WriteLine('')
-        Console.WriteLine('  Including "CreateFile" is optional. By default the file spec of the repository ')
-        Console.WriteLine('  file definition is used.')
+        Console.WriteLine('  Including "CreateFile" is optional. By default the file spec of the ')
+        Console.WriteLine('  repository file definition is used.')
         Console.WriteLine('')
         Console.WriteLine('  Including "LoadFromFile" is optional for ISAM files, if not provided an empty')
-        Console.WriteLine('  file will be created. For relative files you mUST provide an initial data file')
-        Console.WriteLine('  and that file MUST contain at least one record of the appropriate length.')
+        Console.WriteLine('  file will be created. For relative files you mUST provide an initial data ')
+        Console.WriteLine('  file and that file MUST contain at least one record of the appropriate')
+	Console.WriteLine('  length.')
         Console.WriteLine('')
         Console.WriteLine('  Including "OverwriteExistingFile" is optional. By default files will NOT be')
         Console.WriteLine('  overwritten.')

--- a/CreateFile/CreateFileFromRpsFile.dbl
+++ b/CreateFile/CreateFileFromRpsFile.dbl
@@ -93,7 +93,7 @@ proc
     end
         
     if (ok)
-        ok = %DoCreateIsamFile(dcs,filename,a_filespec,a_overwrite,a_filecreated,a_errtxt)
+        ok = %DoCreateIsamFile(dcs,filename,a_filespec,a_overwrite,false,a_filecreated,a_errtxt)
 
     freturn ok
         

--- a/CreateFile/CreateFileFromRpsStruct.dbl
+++ b/CreateFile/CreateFileFromRpsStruct.dbl
@@ -53,12 +53,14 @@ function CreateFileFromRpsStruct,   boolean
         
     stack record
         ok,                         boolean
+	skipspec,		    boolean
         strname,                    String
     endrecord
         
 proc
         
     ok = true
+    skipspec = false
     dcs = a_dcs
     a_filecreated = ""
     a_errtxt = ""
@@ -87,8 +89,17 @@ proc
     begin
         if (!s_info.si_nmfils)
         begin
-            a_errtxt = "Structure definition " + strname + " is not assigned to any files!"
-            ok = false
+	    if (!String.IsNullOrWhiteSpace(a_filespec)) then
+	    begin
+		Console.WriteLine("WARNING: Structure definition " + strname + " is not assigned to any files!")
+		skipspec = true
+		si_file = strname
+	    end
+	    else
+	    begin
+		a_errtxt = "Structure definition " + strname + " is not assigned to any files!"
+		ok = false
+	    end
         end
     end
 
@@ -96,7 +107,7 @@ proc
     if (ok)
     begin
         ;;Create the file
-        ok = %DoCreateIsamFile(dcs,si_file,a_filespec,a_overwrite,a_filecreated,a_errtxt)
+        ok = %DoCreateIsamFile(dcs,si_file,a_filespec,a_overwrite,skipspec,a_filecreated,a_errtxt)
     end
         
     freturn ok

--- a/CreateFile/DoCreateIsamFile.dbl
+++ b/CreateFile/DoCreateIsamFile.dbl
@@ -47,6 +47,7 @@ function DoCreateIsamFile, boolean
     required in  a_filename,    String      ;;Repository file specification name
     required in  a_filespec,    String      ;;Physical file to create (override repository)
     required in  a_overwrite,   boolean     ;;Overwrite existing file?
+    required in	 a_skipspec,	boolean	    ;;Skip dd_filespec?
     required out a_filecreated, String      ;;File name created
     required out a_errtxt,      String      ;;Error text
     endparams
@@ -83,7 +84,8 @@ proc
     dcs = a_dcs
 
     ;;Get the file information record
-    xcall dd_file(dcs,DDL_INFO,a_filename,fl_info)
+    if (!a_skipspec)
+	xcall dd_file(dcs,DDL_INFO,a_filename,fl_info)
     if (dcs.error)
     begin
         a_errtxt = "File definition " + a_filename + " not found!"
@@ -93,7 +95,29 @@ proc
     ;;Get the file specification record for the file
     if (ok)
     begin
-        xcall dd_filespec(dcs,a_filename,,fls_info)
+        if (!a_skipspec) then
+            xcall dd_filespec(dcs,a_filename,,fls_info)
+        else
+        begin
+            ;;Skipping dd_filespec and determining specification from structure
+            xcall dd_struct(dcs,DDS_INFO,a_filename,s_info)
+            if (dcs.error) then
+            begin
+                a_errtxt = "Structure definition " + a_filename + " not found!"
+                ok = false
+            end
+            else
+            begin
+                fls_info.flsi_name = a_filename
+                fls_info.flsi_sname = a_filename
+                fls_info.flsi_recsz = s_info.si_recsz
+                fls_info.flsi_nmkeys = s_info.si_nmkeys
+                fls_info.flsi_filtyp = "DBL ISAM       "
+                ;si_nmkeys may not be correct, as it may include foreign keys as well 
+                ;as access keys, but we'll fix this up later. We could use s_info.si_filtyp
+                ;for fls_info.flsi_filtyp, but it should always be "DBL ISAM" if we've gotten this far.
+            end
+        end
     end
 
     ;;Determine if the file already exists, and if so, whether to replace it
@@ -107,7 +131,7 @@ proc
         try
         begin
             data tmpch, i4, 0
-            open(tmpch,i,fls_info.flsi_name)
+            open(tmpch,i:i,%atrim(fls_info.flsi_name))
             close tmpch
             fileAlreadyExisted = true
         end
@@ -211,7 +235,11 @@ proc
             data key_idx, i4
             keydata = new ArrayList()
 
-            for key_idx from 1 thru fls_info.flsi_nmkeys
+            ;Add all access keys to array
+            ;Loop through all keys until we reach a blank name - we can't use flsi_nmkeys for this loop, because it might cause
+            ;early termination if foreign keys are interspersed with access keys, since flsi_nmkeys only counts access keys.
+            key_idx = 1
+            while (key_idx <= (MAX_KEYS) && keynames[key_idx] .nes. "") do
             begin
                 xcall dd_key(dcs,DDK_INFO,keynames[key_idx],k_info)
                 ;;Keep the access keys, ignore any foreign keys
@@ -226,6 +254,13 @@ proc
                     end
                     keydata.Add((@a)k_info)
                 end
+                key_idx += 1
+            end
+
+            if (a_skipspec)
+            begin
+                fls_info.flsi_nmkeys = keydata.Count
+                ;Fix up number of access keys, in case we skipped dd_filespec and previous value was incorrect
             end
 
             ;;For each key ...
@@ -233,6 +268,7 @@ proc
             begin
                 for key_idx from 1 thru fls_info.flsi_nmkeys
                 begin
+                    data key_isalpha, boolean, true
                     k_info = (a)(keydata[key_idx-1])
 
                     ;;Build the ISAMC key specification string
@@ -266,11 +302,17 @@ proc
                     if (k_info.ki_segdtyp(1))
                     begin
                         append(isamc_keyspec[key_idx],',TYPE='+key_segtyp(k_info.ki_segdtyp(1)))
+                        if (k_info.ki_segdtyp(1) > 2)
+                            key_isalpha = false
                         if (k_info.ki_nmseg>=2)
                         begin
                             data seg_idx, i4
                             for seg_idx from 2 thru k_info.ki_nmseg
+                            begin
                                 append(isamc_keyspec[key_idx],':'+key_segtyp(k_info.ki_segdtyp(seg_idx)))
+                                if (k_info.ki_segdtyp(seg_idx) > 2)
+                                    key_isalpha = false
+                            end
                         end
                     end
 
@@ -346,6 +388,10 @@ proc
 .endc
 
                     ;;Null key?
+.ifdef OS_VMS
+                    if (key_isalpha && k_info.ki_null==KI_REP)
+                        append(isamc_keyspec[key_idx],',NULL=REPLICATE')
+.else
                     using k_info.ki_null select
                     (KI_REP),
                         append(isamc_keyspec[key_idx],',NULL=REPLICATE')
@@ -354,13 +400,35 @@ proc
                     (KI_SHORT),
                         append(isamc_keyspec[key_idx],',NULL=SHORT')
                     endusing
+.endc
 
                     ;;Null key value
-                    if (k_info.ki_nullval)
+                    if (k_info.ki_nullval) then
                     begin
                         data nullval, a255
+                        data nullval_len, d3, 1
+                        ;Select key before checking for text
+                        xcall dd_key(dcs,DDK_INFO,k_info.ki_name,k_info)
                         xcall dd_key(dcs, DDK_TEXT, k_info.ki_nullval, nullval)
-                        append(isamc_keyspec[key_idx],',VALUE_NULL='+%atrim(nullval))
+                        if (dcs.error)
+                        begin
+                            a_errtxt = "Could not retrieve VALUE_NULL for key '" + %atrim(k_info.ki_name) + "'."
+                            ok = false
+                        end
+.ifndef OS_VMS
+                        ;Ensure that a space is used for a blank string, and that only one character is used on VMS
+                        nullval_len = %trim(nullval)
+.endc
+                        append(isamc_keyspec[key_idx],',VALUE_NULL="' + nullval(1:nullval_len) + '"')
+
+                    end
+                    else
+                    begin
+                        if (key_isalpha && k_info.ki_null==KI_NONREP)
+                        begin
+                            Console.WriteLine("WARNING: VALUE_NULL not found for alpha non-replicating null key '" + %atrim(k_info.ki_name) + "'. Using ' '.")
+                            append(isamc_keyspec[key_idx],',VALUE_NULL=" "')
+                        end
                     end
                 end
             end

--- a/CreateFile/DoCreateIsamFile.dbl
+++ b/CreateFile/DoCreateIsamFile.dbl
@@ -69,13 +69,14 @@ function DoCreateIsamFile, boolean
     local record
         key_order,              2a1,    'A'    ;;ascending
         &    ,                          'D'    ;;descending
-        key_segtyp,             7a1,    'A'    ;;alpha (default)
+        key_segtyp,             8a1,    'A'    ;;alpha (default)
         &    ,                          'N'    ;;nocase
         &    ,                          'D'    ;;decimal
         &    ,                          'I'    ;;integer
         &    ,                          'U'    ;;unsigned
         &    ,                          'S'    ;;sequence
         &    ,                          'T'    ;;timestamp
+	&    ,                          'C'    ;;create timestamp
     endrecord
         
 proc
@@ -299,32 +300,60 @@ proc
                     append(isamc_keyspec[key_idx],',NAME='+k_info.ki_name)
 
                     ;;Segment data type (optional)
-                    if (k_info.ki_segdtyp(1))
+                    if (k_info.ki_segdtyp(1) || k_info.ki_segdtyp(2) ||
+		    &	k_info.ki_segdtyp(3) || k_info.ki_segdtyp(4) ||
+		    &	k_info.ki_segdtyp(5) || k_info.ki_segdtyp(6) ||
+		    &	k_info.ki_segdtyp(7) || k_info.ki_segdtyp(8))
                     begin
+			;;In the case of a multi-segment key with different segment types, any
+			;;segment that doesn't specify a type will have a value of 0 (which
+			;;doesn't match any defined type). To allow this code to work, we 
+			;;change 0 to 1 before looking up the type in key_segtyp.
+			;;Note that this assumes that all keys and segments are type alpha, 
+			;;unless otherwise specified. It may be possible to infer the key type 
+			;;by looking up fields in the structure with DD_FIELD, comparing field
+			;;offsets against key segments, and looking up field data types. But
+			;;this could be complicated for non-trivial cases. At present, it is
+			;;recommended to give an explicit type to each non-alpha key segment 
+			;;in the repository structure, so that CreateFile will handle the data
+			;;types correctly.
+			if (k_info.ki_segdtyp(1) == 0)
+			    k_info.ki_segdtyp(1) = 1
+			if (k_info.ki_segdtyp(1) > 2)
+			    key_isalpha = false
                         append(isamc_keyspec[key_idx],',TYPE='+key_segtyp(k_info.ki_segdtyp(1)))
-                        if (k_info.ki_segdtyp(1) > 2)
-                            key_isalpha = false
                         if (k_info.ki_nmseg>=2)
                         begin
                             data seg_idx, i4
                             for seg_idx from 2 thru k_info.ki_nmseg
                             begin
+				if (k_info.ki_segdtyp(seg_idx) == 0)
+				    k_info.ki_segdtyp(seg_idx) = 1
+				if (k_info.ki_segdtyp(seg_idx) > 2)
+				    key_isalpha = false
                                 append(isamc_keyspec[key_idx],':'+key_segtyp(k_info.ki_segdtyp(seg_idx)))
-                                if (k_info.ki_segdtyp(seg_idx) > 2)
-                                    key_isalpha = false
                             end
                         end
                     end
 
                     ;;Segment sequences (optional)
-                    if (k_info.ki_segord(1))
+                    if (k_info.ki_segord(1) || k_info.ki_segord(2) || 
+		    &	k_info.ki_segord(3) || k_info.ki_segord(4) ||
+		    &	k_info.ki_segord(5) || k_info.ki_segord(6) ||
+		    &	k_info.ki_segord(7) || k_info.ki_segord(8))
                     begin
+			if (k_info.ki_segord(1) == 0)
+			    k_info.ki_segord(1) = 1
                         append(isamc_keyspec[key_idx],',ORDER='+key_order(k_info.ki_segord(1)))
                         if (k_info.ki_nmseg>=2)
                         begin
                             data seg_idx, i4
                             for seg_idx from 2 thru k_info.ki_nmseg
+			    begin
+				if (k_info.ki_segord(seg_idx) == 0)
+				    k_info.ki_segord(seg_idx) = 1
                                 append(isamc_keyspec[key_idx],':'+key_order(k_info.ki_segord(seg_idx)))
+			    end
                         end
                     end
 

--- a/CreateFile/DoCreateIsamFile.dbl
+++ b/CreateFile/DoCreateIsamFile.dbl
@@ -455,7 +455,7 @@ proc
                     begin
                         if (key_isalpha && k_info.ki_null==KI_NONREP)
                         begin
-                            Console.WriteLine("WARNING: VALUE_NULL not found for alpha non-replicating null key '" + %atrim(k_info.ki_name) + "'. Using ' '.")
+                            ;Use space as default null value for alpha non-replicating null key.
                             append(isamc_keyspec[key_idx],',VALUE_NULL=" "')
                         end
                     end


### PR DESCRIPTION
I wanted to use CreateFile to create a file for testing ODBC, but it failed because the Repository structure had access keys and foreign keys interspersed, instead of listing all access keys before foreign keys. While fixing this issue, I found a few other areas where the program could be improved to make it more useful. Here are the changes that I made, to the best of my recollection:
- Added command line options -rm and -rt to explicitly specify Repository main and text files. I added these to help test my changes from Visual Studio, but they may be helpful in other cases as well.
- Updated usage info to show a new version number and describe updated features, and formatted text better for an 80-column window.
- Added the ability to create a file directly from a Repository structure when no matching file is defined in the Repository. This requires an explicit filespec specified with the -out option, and will generate a warning.
- Updated list of segment types to include 'C' (create timestamp).
- Fixed test for existing ISAM file (by specifying "i:i" open mode).
- Fixed issue where a Repository structure that intersperses access keys and foreign keys caused file creation to fail with an index out of range error.
- Fixed issue where segment types weren't set correctly for multi-segment keys with different key types for different segments. Note that we are getting segment type from the key definition and not the underlying field definition, so types may be incorrect if not explicitly specified in key definitions.
- Fixed issue where the lack of an explicit VALUE_NULL for an alpha non-replicating null key caused file creation to fail with "Illegal key specified".